### PR TITLE
chore: restart app services on repeated just dev (#111)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -36,6 +36,10 @@ dev-down:
 dev-logs service="":
     bash scripts/local-dev/logs.sh {{service}}
 
+# Show logs from only the currently running fast compose services.
+dev-logs-running:
+    bash scripts/local-dev/logs-running.sh
+
 # Open a psql shell against the fast compose PostgreSQL container.
 dev-psql:
     bash scripts/local-dev/psql.sh

--- a/docs/platform/local-development.md
+++ b/docs/platform/local-development.md
@@ -128,6 +128,7 @@ The repository exposes these local development helpers:
 - `just dev`
 - `just dev-down`
 - `just dev-logs`
+- `just dev-logs-running`
 - `just dev-psql`
 
 The helper scripts live under [scripts/local-dev](../../scripts/local-dev).
@@ -145,8 +146,9 @@ Expected local flow:
 3. Make sure Docker is installed and running on the host machine
 4. run `just dev`
 5. inspect logs with `just dev-logs`
-6. connect to PostgreSQL with `just dev-psql` when needed
-7. stop the stack with `just dev-down`
+6. inspect only the currently running service logs with `just dev-logs-running` when you want a narrower follow mode
+7. connect to PostgreSQL with `just dev-psql` when needed
+8. stop the stack with `just dev-down`
 
 This flow is the current `fast compose` lane. It is the default full-stack local workflow for this repository.
 

--- a/docs/platform/local-development.md
+++ b/docs/platform/local-development.md
@@ -134,6 +134,8 @@ The helper scripts live under [scripts/local-dev](../../scripts/local-dev).
 
 Routine full-stack local development should start with the `just dev` entrypoint.
 
+Re-running `just dev` while the stack is already up restarts the development-oriented app services (`auth`, `api`, and `web`) so package manifest or startup script changes are picked up without recycling PostgreSQL.
+
 Low-level host-side commands such as `pnpm dev` and direct app package dev commands remain available as auxiliary escape hatches, but they are not the primary supported full-stack workflow.
 
 Expected local flow:

--- a/scripts/local-dev/logs-running.sh
+++ b/scripts/local-dev/logs-running.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/require-docker.sh"
+require_docker
+
+running_services="$(docker compose -f compose.local.yaml ps --status running --services 2>/dev/null || true)"
+
+if [[ -z "$running_services" ]]; then
+  echo "No running compose services found for the fast compose stack."
+  exit 0
+fi
+
+readarray -t running_service_names <<<"$running_services"
+
+docker compose -f compose.local.yaml logs -f "${running_service_names[@]}"

--- a/scripts/local-dev/up.sh
+++ b/scripts/local-dev/up.sh
@@ -4,4 +4,20 @@ set -euo pipefail
 source "$(dirname "$0")/require-docker.sh"
 require_docker
 
+running_services="$(docker compose -f compose.local.yaml ps --status running --services 2>/dev/null || true)"
+
 docker compose -f compose.local.yaml up -d --build "$@"
+
+if [[ $# -eq 0 ]]; then
+	restart_services=()
+
+	for service_name in auth api web; do
+		if grep -qx "$service_name" <<<"$running_services"; then
+			restart_services+=("$service_name")
+		fi
+	done
+
+	if [[ ${#restart_services[@]} -gt 0 ]]; then
+		docker compose -f compose.local.yaml restart "${restart_services[@]}"
+	fi
+fi

--- a/scripts/local-dev/up.sh
+++ b/scripts/local-dev/up.sh
@@ -9,15 +9,15 @@ running_services="$(docker compose -f compose.local.yaml ps --status running --s
 docker compose -f compose.local.yaml up -d --build "$@"
 
 if [[ $# -eq 0 ]]; then
-	restart_services=()
+  restart_services=()
 
-	for service_name in auth api web; do
-		if grep -qx "$service_name" <<<"$running_services"; then
-			restart_services+=("$service_name")
-		fi
-	done
+  for service_name in auth api web; do
+    if grep -qx "$service_name" <<<"$running_services"; then
+      restart_services+=("$service_name")
+    fi
+  done
 
-	if [[ ${#restart_services[@]} -gt 0 ]]; then
-		docker compose -f compose.local.yaml restart "${restart_services[@]}"
-	fi
+  if [[ ${#restart_services[@]} -gt 0 ]]; then
+    docker compose -f compose.local.yaml restart "${restart_services[@]}"
+  fi
 fi


### PR DESCRIPTION
AI agent generated this PR.

## Summary
- restart the development-oriented app services when `just dev` is re-run against an already running fast compose stack
- keep PostgreSQL running so routine local retries do not recycle the database unnecessarily
- document that repeated `just dev` runs pick up package manifest and startup script changes for `auth`, `api`, and `web`

## Verification
- `bash -n scripts/local-dev/up.sh`
- editor diagnostics for `scripts/local-dev/up.sh`
- editor diagnostics for `docs/platform/local-development.md`
