### PR TITLE
feat: add parity compose validation path (#112)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -40,13 +40,25 @@ generate:
 dev:
     bash scripts/local-dev/up.sh
 
+# Start the parity compose validation path with built runtimes and health waits.
+parity:
+    bash scripts/local-dev/parity-up.sh
+
 # Stop the default fast compose local development path.
 dev-down:
     bash scripts/local-dev/down.sh
 
+# Stop the parity compose validation path.
+parity-down:
+    bash scripts/local-dev/parity-down.sh
+
 # Show logs from the default fast compose local development path.
 dev-logs service="":
     bash scripts/local-dev/logs.sh {{service}}
+
+# Show logs from the parity compose validation path.
+parity-logs service="":
+    bash scripts/local-dev/parity-logs.sh {{service}}
 
 # Show logs from only the currently running fast compose services.
 dev-logs-running:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The supported local execution modes and env contract are documented in [docs/pla
 
 For routine full-stack local development, use `just dev`.
 
+For production-oriented local validation with built runtimes and health waits, use `just parity`.
+
 Low-level host-side commands such as `pnpm dev` remain available for narrow debugging, but they are not the primary documented full-stack workflow.
 
 ### Commit Message Tooling Demo

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
     "contract:build": "pnpm --dir ../.. --filter @focusbuddy/api-contract build",
     "dev": "pnpm contract:build && pnpm prisma:generate && pnpm exec nest start --watch",
     "lint": "pnpm --dir ../.. exec oxlint apps/api/src apps/api/test apps/api/prisma",
+    "parity": "pnpm build && node dist/main.js",
     "prisma:generate": "prisma generate --config prisma.config.ts",
     "prisma:migrate:dev": "prisma migrate dev --config prisma.config.ts",
     "prisma:studio": "prisma studio --config prisma.config.ts",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "dev:compose": "pnpm contract:build && next dev --hostname 0.0.0.0 --port 3000",
     "lint": "pnpm lint:styles && pnpm --dir ../.. exec oxlint apps/web/src apps/web/test",
     "lint:styles": "pnpm --dir ../.. exec stylelint \"apps/web/src/**/*.css\"",
+    "parity": "pnpm build && next start --hostname 0.0.0.0 --port 3000",
     "test": "pnpm contract:build && pnpm --dir ../.. exec jest --config apps/web/jest.config.ts --runInBand",
     "typecheck": "pnpm contract:build && pnpm --dir ../.. exec tsc --project apps/web/tsconfig.json --noEmit"
   },

--- a/compose.parity.yaml
+++ b/compose.parity.yaml
@@ -1,0 +1,10 @@
+services:
+  api:
+    command: ['pnpm', '--filter', '@focusbuddy/api', 'parity']
+    environment:
+      NODE_ENV: production
+
+  web:
+    command: ['pnpm', '--filter', '@focusbuddy/web', 'parity']
+    environment:
+      NODE_ENV: production

--- a/compose.parity.yaml
+++ b/compose.parity.yaml
@@ -3,8 +3,14 @@ services:
     command: ['pnpm', '--filter', '@focusbuddy/api', 'parity']
     environment:
       NODE_ENV: production
+    healthcheck:
+      start_period: 60s
+      retries: 12
 
   web:
     command: ['pnpm', '--filter', '@focusbuddy/web', 'parity']
     environment:
       NODE_ENV: production
+    healthcheck:
+      start_period: 60s
+      retries: 12

--- a/docs/platform/local-development.md
+++ b/docs/platform/local-development.md
@@ -129,8 +129,11 @@ The repository exposes these local development helpers:
 - `just openapi`
 - `just prisma <migration-name>`
 - `just dev`
+- `just parity`
 - `just dev-down`
+- `just parity-down`
 - `just dev-logs`
+- `just parity-logs`
 - `just dev-logs-running`
 - `just dev-psql`
 
@@ -164,6 +167,35 @@ Expected local flow:
 
 This flow is the current `fast compose` lane. It is the default full-stack local workflow for this repository.
 
+## Parity compose flow
+
+The repository also exposes a `parity compose` lane for production-oriented local validation.
+
+- start it with `just parity`
+- inspect it with `just parity-logs`
+- stop it with `just parity-down`
+
+The first parity implementation is intentionally narrow.
+
+- it still uses the Compose-managed local PostgreSQL and local auth stub topology
+- it replaces development runtimes with built-runtime commands for API and web
+- it waits for Compose health checks before reporting success
+
+The initial must-match checks in this lane are:
+
+- API must boot from built output instead of a watch runner
+- web must boot from `next build` plus `next start` instead of `next dev`
+- API must still start against the explicit Compose `DATABASE_URL` that targets the `postgres` service hostname
+- auth, api, and web must all become healthy under the stricter startup path before the lane is considered ready
+
+Because parity compose reuses the same published local ports as the fast lane, switch lanes explicitly.
+
+1. stop fast compose with `just dev-down`
+2. start parity compose with `just parity`
+3. inspect logs with `just parity-logs`
+4. stop parity compose with `just parity-down`
+5. return to the default lane with `just dev` when you are done validating
+
 ## Relationship to the dev container
 
 The dev container and the local Docker compose stack solve different problems.
@@ -190,7 +222,7 @@ The first local stack intentionally differs from production in these ways:
 
 These differences are acceptable for the current stage because the goal is to make the local workflow explicit and reproducible before full app implementation begins.
 
-For the distinction between the default `fast compose` path, the future `parity compose` path, and host-side auxiliary startup, see [local-execution-modes.md](./local-execution-modes.md).
+For the distinction between the default `fast compose` path, the implemented `parity compose` path, and host-side auxiliary startup, see [local-execution-modes.md](./local-execution-modes.md).
 
 ## Handoff to follow-up issues
 

--- a/docs/platform/local-execution-modes.md
+++ b/docs/platform/local-execution-modes.md
@@ -8,7 +8,7 @@ Its purpose is to define the local execution lane policy for FocusBuddy, describ
 
 This document defines:
 
-- the current full-stack local development path and the planned parity-oriented path
+- the current full-stack local development path and the implemented parity-oriented path
 - the role of host-side direct app startup as an auxiliary path
 - the local env contract at the configuration-category level
 - a short decision guide for choosing a mode
@@ -21,7 +21,7 @@ FocusBuddy distinguishes two full-stack local execution lanes.
 
 Today, `fast compose` is the implemented default lane.
 
-`parity compose` is the planned production-oriented lane that this repository intends to add in follow-up work.
+`parity compose` is the implemented production-oriented lane for local runtime validation.
 
 The repository needs both lanes because they optimize for different kinds of confidence.
 
@@ -39,10 +39,11 @@ The repository needs both lanes because they optimize for different kinds of con
 
 ### `parity compose`
 
-- is the planned production-oriented local validation path
-- is expected to run through `docker compose`
-- is intended to run built artifacts with stricter startup assumptions than the fast lane
-- exists to catch drift that should also fail in deployed environments once implemented
+- is the production-oriented local validation path
+- is started through `just parity`
+- runs through `docker compose` with the parity overlay
+- runs built artifacts with stricter startup assumptions than the fast lane
+- exists to catch drift that should also fail in deployed environments
 
 ## Auxiliary path
 
@@ -57,7 +58,7 @@ This path is not documented as the default full-stack workflow because supportin
 | Lane | Primary purpose | Runtime shape | Why it is not enough by itself |
 | --- | --- | --- | --- |
 | `fast compose` | day-to-day implementation speed | Compose-managed stack with development runtimes | can hide failures that only appear with built artifacts or stricter startup assumptions |
-| `parity compose` | production-oriented local validation | planned Compose-managed stack with built artifacts and stricter startup | too heavy for routine editing and not yet implemented |
+| `parity compose` | production-oriented local validation | Compose-managed stack with built runtimes and stricter startup | too heavy for routine editing and therefore not the default lane |
 | host-side direct startup | narrow debugging escape hatch | web and api started from the dev container, with PostgreSQL and auth started separately | diverges from the repository's default full-stack topology |
 
 ## Execution lane diagram
@@ -87,12 +88,12 @@ flowchart TB
 
     GAP --> PC
 
-    subgraph PC[parity compose: planned validation lane]
-        PC_ENTRY[planned parity compose entrypoint]
-        PC_WEB[planned web built runtime container]
-        PC_API[planned api built runtime container]
+    subgraph PC[parity compose: implemented validation lane]
+        PC_ENTRY[just parity]
+        PC_WEB[web built runtime container]
+        PC_API[api built runtime container]
         PC_DB[(postgres container)]
-        PC_AUTH[(planned auth runtime)]
+        PC_AUTH[(auth stub container)]
         PC_ENTRY --> PC_WEB
         PC_ENTRY --> PC_API
         PC_ENTRY --> PC_DB
@@ -129,7 +130,18 @@ The important difference is not only where the processes run.
 - in `parity compose`, the repository can validate failures that the fast lane may miss because of dev-oriented runtime behavior
 - in the host-side path, web and api may run directly from the dev container, but PostgreSQL must still be started as another container and auth must still be started separately, which is why the repository does not treat that path as the default full-stack contract
 
-The parity lane is shown as planned because the repository does not yet provide a dedicated parity Compose entrypoint.
+The parity lane now has a dedicated Compose entrypoint and exists specifically to validate runtime behavior that the fast lane can hide.
+
+## Initial parity checks
+
+The first parity implementation keeps the lane narrow and focuses on must-match runtime checks that are immediately useful.
+
+- API starts from built output through `node dist/main.js` instead of the watch-oriented Nest development runner
+- web starts from `next build` plus `next start` instead of `next dev`
+- the Compose-managed `DATABASE_URL` path remains explicit and must still reach PostgreSQL through the `postgres` service hostname
+- Compose waits for auth, api, and web health checks before the lane reports success
+
+This is intentionally narrower than a full production clone, but it already exercises built artifacts and stricter startup behavior that the fast lane does not enforce.
 
 ## Env contract
 
@@ -146,7 +158,7 @@ The tracked local inputs currently cover categories such as:
 - local auth mode
 - optional bind mount source override for Docker-from-dev-container workflows
 
-These categories should stay aligned across the current fast lane and the planned parity lane.
+These categories should stay aligned across the current fast lane and the parity lane.
 
 ### Mode-specific derived values
 
@@ -182,9 +194,10 @@ Use `fast compose` when:
 - you are doing day-to-day feature development
 - you need the app and supporting services started together
 
-Use `parity compose` after it is implemented when:
+Use `parity compose` when:
 
 - you want a production-oriented local validation path
+- you want the parity entrypoint, `just parity`
 - you need to check startup assumptions that should also hold in deployed environments
 - you want to catch drift hidden by development servers or looser startup behavior
 

--- a/scripts/local-dev/parity-down.sh
+++ b/scripts/local-dev/parity-down.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/require-docker.sh"
+require_docker
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+
+cd "$repo_root"
+docker compose -f compose.local.yaml -f compose.parity.yaml down "$@"

--- a/scripts/local-dev/parity-down.sh
+++ b/scripts/local-dev/parity-down.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-source "$(dirname "$0")/require-docker.sh"
-require_docker
-
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
 
 cd "$repo_root"
+
+source "$(dirname "$0")/require-docker.sh"
+require_docker
+
 docker compose -f compose.local.yaml -f compose.parity.yaml down "$@"

--- a/scripts/local-dev/parity-logs.sh
+++ b/scripts/local-dev/parity-logs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/require-docker.sh"
+require_docker
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+service_name="${1:-}"
+
+cd "$repo_root"
+
+if [[ -n "$service_name" ]]; then
+  docker compose -f compose.local.yaml -f compose.parity.yaml logs -f "$service_name"
+else
+  docker compose -f compose.local.yaml -f compose.parity.yaml logs -f
+fi

--- a/scripts/local-dev/parity-logs.sh
+++ b/scripts/local-dev/parity-logs.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-source "$(dirname "$0")/require-docker.sh"
-require_docker
-
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
 service_name="${1:-}"
 
 cd "$repo_root"
+
+source "$(dirname "$0")/require-docker.sh"
+require_docker
 
 if [[ -n "$service_name" ]]; then
   docker compose -f compose.local.yaml -f compose.parity.yaml logs -f "$service_name"

--- a/scripts/local-dev/parity-up.sh
+++ b/scripts/local-dev/parity-up.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/require-docker.sh"
+require_docker
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+
+cd "$repo_root"
+docker compose -f compose.local.yaml -f compose.parity.yaml up -d --build --wait "$@"

--- a/scripts/local-dev/parity-up.sh
+++ b/scripts/local-dev/parity-up.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-source "$(dirname "$0")/require-docker.sh"
-require_docker
-
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
 
 cd "$repo_root"
+
+source "$(dirname "$0")/require-docker.sh"
+require_docker
+
 docker compose -f compose.local.yaml -f compose.parity.yaml up -d --build --wait "$@"


### PR DESCRIPTION
AI agent generated this PR.

## Summary
- add a parity compose overlay and `just parity` entrypoints for production-oriented local validation
- run built API and web runtimes in the parity lane instead of watch/dev servers
- document the implemented parity lane, its purpose, and the initial must-match runtime checks

## Verification
- `bash -n scripts/local-dev/parity-up.sh`
- `bash -n scripts/local-dev/parity-down.sh`
- `bash -n scripts/local-dev/parity-logs.sh`
- `just --list`
- `docker compose -f compose.local.yaml -f compose.parity.yaml config`
- `pnpm --filter @focusbuddy/api build`
- `pnpm --filter @focusbuddy/web build`
- editor diagnostics for `Justfile`
- editor diagnostics for `compose.parity.yaml`
- editor diagnostics for `apps/api/package.json`
- editor diagnostics for `apps/web/package.json`
- editor diagnostics for `docs/platform/local-development.md`
- editor diagnostics for `docs/platform/local-execution-modes.md`
- editor diagnostics for `README.md`
