### PR TITLE
fix: stabilize jest config type imports

### DIFF
--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -1,11 +1,11 @@
 /** @jest-config-loader ts-node */
 /** @jest-config-loader-options {"transpileOnly": true} */
 
-import type { Config } from 'jest';
+import type { Config } from '@jest/types';
 
 import sharedConfig from '../../packages/config-jest/api.ts';
 
-const config: Config = {
+const config: Config.InitialOptions = {
   ...sharedConfig,
   moduleFileExtensions: [...(sharedConfig.moduleFileExtensions ?? []), 'ts'],
   roots: ['<rootDir>/src', '<rootDir>/test'],

--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -1,11 +1,10 @@
 /** @jest-config-loader ts-node */
 /** @jest-config-loader-options {"transpileOnly": true} */
 
-import type { Config } from '@jest/types';
-
+import { defineJestConfig } from '../../packages/config-jest/define.ts';
 import sharedConfig from '../../packages/config-jest/api.ts';
 
-const config: Config.InitialOptions = {
+const config = defineJestConfig({
   ...sharedConfig,
   moduleFileExtensions: [...(sharedConfig.moduleFileExtensions ?? []), 'ts'],
   roots: ['<rootDir>/src', '<rootDir>/test'],
@@ -18,6 +17,6 @@ const config: Config.InitialOptions = {
       },
     ],
   },
-};
+});
 
 export default config;

--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -1,14 +1,14 @@
 /** @jest-config-loader ts-node */
 /** @jest-config-loader-options {"transpileOnly": true} */
 
-import type { Config } from '@jest/types';
 import nextJest from 'next/jest.js';
 
+import { defineJestConfig } from '../../packages/config-jest/define.ts';
 import sharedConfig from '../../packages/config-jest/web.ts';
 
 const createJestConfig = nextJest({ dir: './apps/web' });
 
-const config: Config.InitialOptions = {
+const config = defineJestConfig({
   ...sharedConfig,
   rootDir: '.',
   moduleDirectories: ['node_modules', '<rootDir>/src', '<rootDir>/test'],
@@ -16,6 +16,6 @@ const config: Config.InitialOptions = {
   setupFilesAfterEnv: ['<rootDir>/test/setup-tests.ts'],
   testMatch: ['<rootDir>/test/**/*.test.ts?(x)'],
   transformIgnorePatterns: ['/node_modules/(?!(msw|@mswjs|@open-draft/until)/)'],
-};
+});
 
 export default createJestConfig(config);

--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -1,14 +1,14 @@
 /** @jest-config-loader ts-node */
 /** @jest-config-loader-options {"transpileOnly": true} */
 
-import type { Config } from 'jest';
+import type { Config } from '@jest/types';
 import nextJest from 'next/jest.js';
 
 import sharedConfig from '../../packages/config-jest/web.ts';
 
 const createJestConfig = nextJest({ dir: './apps/web' });
 
-const config: Config = {
+const config: Config.InitialOptions = {
   ...sharedConfig,
   rootDir: '.',
   moduleDirectories: ['node_modules', '<rootDir>/src', '<rootDir>/test'],

--- a/docs/platform/shared-tooling.md
+++ b/docs/platform/shared-tooling.md
@@ -44,7 +44,9 @@ This document does not define application code, end-to-end test strategy, or dep
 - `base.ts` defines the shared Jest defaults
 - `api.ts` sets the API test environment to Node
 - `web.ts` sets the web test environment to jsdom
+- `define.ts` owns the shared Jest config type contract for tooling files in this repo
 - the repository uses `ts-node` as the Jest config loader for TypeScript-based config files
+- app-level Jest config files should consume the shared config typing helper instead of importing low-level Jest type packages directly
 - the shared Jest baselines stay directory-agnostic until the real app source trees exist in follow-up issues
 - the shared Jest baselines do not enable TypeScript test execution until a real transform is chosen in follow-up app work
 

--- a/packages/config-jest/README.md
+++ b/packages/config-jest/README.md
@@ -13,6 +13,12 @@ Current consumers:
 - `apps/api/jest.config.ts`
 - `apps/web/jest.config.ts`
 
+Typing rule:
+
+- `@focusbuddy/config-jest` owns the Jest config type contract for the repo
+- app-level Jest config files should use `defineJestConfig` from this package instead of importing `@jest/types` directly
+- this keeps Jest config typing deterministic without making each app workspace own the low-level Jest type package
+
 The repository uses `ts-node` to load TypeScript-based Jest config files.
 
 The shared Jest baselines do not require `src` or `test` directories yet. Follow-up app issues can add tighter roots when real source trees exist.

--- a/packages/config-jest/api.ts
+++ b/packages/config-jest/api.ts
@@ -1,8 +1,8 @@
-import type { Config } from 'jest';
+import type { Config } from '@jest/types';
 
 import baseConfig from './base.ts';
 
-const config: Config = {
+const config: Config.InitialOptions = {
   ...baseConfig,
   testEnvironment: 'node',
 };

--- a/packages/config-jest/api.ts
+++ b/packages/config-jest/api.ts
@@ -1,10 +1,9 @@
-import type { Config } from '@jest/types';
-
 import baseConfig from './base.ts';
+import { defineJestConfig } from './define.ts';
 
-const config: Config.InitialOptions = {
+const config = defineJestConfig({
   ...baseConfig,
   testEnvironment: 'node',
-};
+});
 
 export default config;

--- a/packages/config-jest/base.ts
+++ b/packages/config-jest/base.ts
@@ -1,6 +1,6 @@
-import type { Config } from 'jest';
+import type { Config } from '@jest/types';
 
-const config: Config = {
+const config: Config.InitialOptions = {
   clearMocks: true,
   coveragePathIgnorePatterns: [
     '/node_modules/',

--- a/packages/config-jest/base.ts
+++ b/packages/config-jest/base.ts
@@ -1,6 +1,6 @@
-import type { Config } from '@jest/types';
+import { defineJestConfig } from './define.ts';
 
-const config: Config.InitialOptions = {
+const config = defineJestConfig({
   clearMocks: true,
   coveragePathIgnorePatterns: [
     '/node_modules/',
@@ -19,6 +19,6 @@ const config: Config.InitialOptions = {
     '/generated/',
     '/__generated__/',
   ],
-};
+});
 
 export default config;

--- a/packages/config-jest/define.ts
+++ b/packages/config-jest/define.ts
@@ -1,0 +1,5 @@
+import type { Config } from '@jest/types';
+
+export type JestConfig = Config.InitialOptions;
+
+export const defineJestConfig = <T extends JestConfig>(config: T): T => config;

--- a/packages/config-jest/package.json
+++ b/packages/config-jest/package.json
@@ -5,12 +5,17 @@
   "files": [
     "base.ts",
     "api.ts",
-    "web.ts"
+    "web.ts",
+    "define.ts"
   ],
   "exports": {
     "./base": "./base.ts",
     "./api": "./api.ts",
-    "./web": "./web.ts"
+    "./web": "./web.ts",
+    "./define": "./define.ts"
+  },
+  "devDependencies": {
+    "@jest/types": "^30.3.0"
   },
   "scripts": {
     "build": "node ../../scripts/workspace-task.mjs @focusbuddy/config-jest build",

--- a/packages/config-jest/web.ts
+++ b/packages/config-jest/web.ts
@@ -1,10 +1,9 @@
-import type { Config } from '@jest/types';
-
 import baseConfig from './base.ts';
+import { defineJestConfig } from './define.ts';
 
-const config: Config.InitialOptions = {
+const config = defineJestConfig({
   ...baseConfig,
   testEnvironment: 'jsdom',
-};
+});
 
 export default config;

--- a/packages/config-jest/web.ts
+++ b/packages/config-jest/web.ts
@@ -1,8 +1,8 @@
-import type { Config } from 'jest';
+import type { Config } from '@jest/types';
 
 import baseConfig from './base.ts';
 
-const config: Config = {
+const config: Config.InitialOptions = {
   ...baseConfig,
   testEnvironment: 'jsdom',
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,7 +166,11 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
 
-  packages/config-jest: {}
+  packages/config-jest:
+    devDependencies:
+      '@jest/types':
+        specifier: ^30.3.0
+        version: 30.3.0
 
   packages/config-oxlint: {}
 


### PR DESCRIPTION
AI agent generated PR.

## Summary
- replace fragile Jest config typing that could resolve to non-module `@types/jest/index.d.ts`
- centralize the Jest config type contract in `@focusbuddy/config-jest`
- switch app-level Jest config files to a shared `defineJestConfig(...)` helper instead of importing low-level Jest type packages directly
- add the explicit `@jest/types` dependency only where that type contract is owned
- refresh `pnpm-lock.yaml` so CI can install with `--frozen-lockfile`

## Design
- `@focusbuddy/config-jest` is the single owner of Jest config typing in this repository
- app workspaces consume that contract through `packages/config-jest/define.ts`
- app-level `jest.config.ts` files do not import `@jest/types` directly
- the low-level Jest type package is declared once in `packages/config-jest/package.json`, which keeps dependency ownership and pnpm resolution deterministic
- this design is documented in `packages/config-jest/README.md` and `docs/platform/shared-tooling.md`

## Validation
- verified no editor errors remain for the touched Jest config files
- regenerated `pnpm-lock.yaml` to match the new shared package dependency
- PR checks are green: Merge Gate and CodeQL succeeded

Closes #138
