### PR TITLE
test(config-jest): support ESM package consumption

### DIFF
--- a/apps/api/test/config-jest-esm-support.spec.ts
+++ b/apps/api/test/config-jest-esm-support.spec.ts
@@ -1,0 +1,34 @@
+import { defineJestConfig, withEsmPackageSupport } from '../../../packages/config-jest/define.ts'
+
+describe('withEsmPackageSupport', () => {
+  it('replaces the node_modules ignore pattern with one allowlist pattern', () => {
+    const config = withEsmPackageSupport(
+      defineJestConfig({
+        transformIgnorePatterns: ['/node_modules/', '/dist/'],
+      }),
+      {
+        packageNames: ['msw', '@mswjs', '@open-draft/until'],
+      },
+    )
+
+    expect(config.transformIgnorePatterns).toEqual([
+      '/node_modules/(?!(?:msw|@mswjs|@open-draft/until)(?:/|$))/',
+      '/dist/',
+    ])
+  })
+
+  it('merges ESM extensions without duplicates', () => {
+    const config = withEsmPackageSupport(
+      defineJestConfig({
+        extensionsToTreatAsEsm: ['.ts'],
+        transformIgnorePatterns: ['/node_modules/'],
+      }),
+      {
+        extensionsToTreatAsEsm: ['.tsx', '.ts'],
+      },
+    )
+
+    expect(config.extensionsToTreatAsEsm).toEqual(['.ts', '.tsx'])
+    expect(config.transformIgnorePatterns).toEqual(['/node_modules/'])
+  })
+})

--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -3,19 +3,23 @@
 
 import nextJest from 'next/jest.js';
 
-import { defineJestConfig } from '../../packages/config-jest/define.ts';
+import { defineJestConfig, withEsmPackageSupport } from '../../packages/config-jest/define.ts';
 import sharedConfig from '../../packages/config-jest/web.ts';
 
 const createJestConfig = nextJest({ dir: './apps/web' });
 
-const config = defineJestConfig({
-  ...sharedConfig,
-  rootDir: '.',
-  moduleDirectories: ['node_modules', '<rootDir>/src', '<rootDir>/test'],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'cjs', 'mjs', 'json'],
-  setupFilesAfterEnv: ['<rootDir>/test/setup-tests.ts'],
-  testMatch: ['<rootDir>/test/**/*.test.ts?(x)'],
-  transformIgnorePatterns: ['/node_modules/(?!(msw|@mswjs|@open-draft/until)/)'],
-});
+const config = withEsmPackageSupport(
+  defineJestConfig({
+    ...sharedConfig,
+    rootDir: '.',
+    moduleDirectories: ['node_modules', '<rootDir>/src', '<rootDir>/test'],
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'cjs', 'mjs', 'json'],
+    setupFilesAfterEnv: ['<rootDir>/test/setup-tests.ts'],
+    testMatch: ['<rootDir>/test/**/*.test.ts?(x)'],
+  }),
+  {
+    packageNames: ['msw', '@mswjs', '@open-draft/until'],
+  },
+);
 
 export default createJestConfig(config);

--- a/docs/platform/esm-migration-strategy.md
+++ b/docs/platform/esm-migration-strategy.md
@@ -20,6 +20,7 @@ This document does not define a repository-wide app runtime conversion to pure E
 
 - explicit ESM is opt-in per package; one package changing module mode does not authorize ad hoc conversion of unrelated packages
 - runtime packages that other workspaces import at runtime should prefer built artifact exports over raw source file exports before they become explicit ESM packages
+- runtime packages should default to explicit ESM-only exports and should add a CommonJS `require` path only when a verified current consumer or tool still blocks on it
 - config packages consumed directly by tools should not become explicit ESM packages until the consuming toolchain contract is documented and verified
 - a package must keep CommonJS compatibility whenever any current consumer or tool still relies on `require()` or a CommonJS-only loader path
 - no package may switch to explicit ESM without a documented export surface, build output contract, and verification plan
@@ -31,7 +32,7 @@ This document does not define a repository-wide app runtime conversion to pure E
 | `packages/logger` | explicit ESM runtime package | keep as the repository's simplest runtime-package reference | uses `type: module`, explicit ESM export entrypoints, and TypeScript-emitted build artifacts |
 | `packages/api-contract` | source-export package with generated `.ts` outputs and a CommonJS helper entry | next runtime package candidate after a build contract is defined | should not expose generated source files as the long-term runtime contract once it becomes explicit ESM |
 | `packages/config-typescript` | exports shared JSON config files | keep current mode for now | TypeScript config consumers do not benefit from package-level ESM and still depend on current tool loading behavior |
-| `packages/config-jest` | exports raw `.ts` config modules | coordinated migration only | current consumers rely on TypeScript config loading and Jest-specific loader behavior |
+| `packages/config-jest` | exports raw `.ts` config modules with a shared ESM-consumption helper | coordinated migration only | the shared baseline now owns `node_modules` allowlist rules for ESM package consumption, but the package itself still relies on TypeScript config loading and Jest-specific loader behavior |
 | `packages/config-oxlint` | exports raw `.ts` config modules | coordinated migration only | current consumers depend on tool execution of TypeScript config files |
 | `packages/config-prettier` | CommonJS-only `index.cjs` entry | keep CommonJS | Prettier config loading still requires a stable CommonJS path in this repository |
 | `apps/api` | NodeNext TypeScript app consumer | not a package-conversion target in this issue | app runtime strategy remains separate from package migration strategy |
@@ -46,9 +47,9 @@ Any workspace package that becomes an explicit ESM package must satisfy all of t
 2. export only documented public entrypoints through `exports`
 3. publish built JavaScript artifacts instead of exposing raw `.ts` source files as the primary runtime contract
 4. provide `types` entries for every public subpath
-5. provide a `require` condition whenever any current consumer still needs CommonJS compatibility
+5. omit the CommonJS `require` condition by default and add it only when a verified current consumer or tool still needs CommonJS compatibility
 6. use NodeNext-compatible relative import specifiers in source where emitted JavaScript requires them
-7. include verification that both the ESM import path and any required CommonJS path still resolve correctly
+7. include verification that the ESM import path resolves correctly and that any retained CommonJS path still resolves when one is intentionally kept
 
 The logger package is the current repository reference for a runtime package that can move to explicit ESM without retaining a separate CommonJS artifact. Future package migrations should copy the contract shape that matches their actual consumers, not preserve CommonJS by default.
 
@@ -56,13 +57,16 @@ The logger package is the current repository reference for a runtime package tha
 
 ### Jest and TypeScript test loading
 
-The API workspace currently uses `ts-jest` with the local TypeScript config and does not enable Jest's ESM mode. That means a workspace package can expose explicit ESM only if test consumers continue to resolve through a compatible path.
+The shared Jest baseline now includes one repository-owned way to consume ESM packages from Jest configs: `withEsmPackageSupport` in `packages/config-jest`. The current web Jest setup already uses that helper to allowlist specific ESM packages under `node_modules`.
 
-Before more runtime packages become explicit ESM packages, the shared Jest baseline should be updated so the repository has one documented answer for:
+The API workspace still uses `ts-jest` with the local TypeScript config and does not enable Jest's ESM mode by default. That means the next ESM-only runtime package consumed by API tests should update the API Jest transform at the same time instead of forcing the package back to CommonJS compatibility.
 
-- when `ts-jest` should run with `useESM: true`
-- when `.ts` should be treated as ESM in test resolution
-- how package tests verify both `import` and `require` conditions where dual publish remains necessary
+For this repository, the current Jest rule is:
+
+- use the shared Jest baseline to own `transformIgnorePatterns` allowlists for ESM packages under `node_modules`
+- add `extensionsToTreatAsEsm` through the shared helper only when the consuming app is actually opting into Jest ESM execution
+- pair `withEsmPackageSupport` with `ts-jest` `useESM: true` in the API workspace when the first ESM-only runtime package enters API test execution
+- verify `require` behavior only for packages that intentionally retain a CommonJS path
 
 ### Tool-owned config packages
 
@@ -94,20 +98,18 @@ The repository build and test tasks rely on upstream workspace builds through Tu
 
 ## Ordered follow-up plan
 
-1. keep `packages/logger` as the reference implementation and use it as the contract template for future runtime packages
-2. define the shared Jest and test-runner rules required to consume explicit ESM workspace packages safely
-3. define the build output and export contract for `packages/api-contract` so generated source stops being the primary runtime surface
-4. migrate `packages/api-contract` only after its build and consumer contract are documented
-5. decide whether config packages should remain direct source-export tool packages or move to a separate built-distribution model before attempting any config-package ESM change
-6. revisit application runtime module strategy only after package-level migration rules are stable and proven in at least one additional package
+1. keep `packages/logger` as the ESM-only runtime reference and `packages/config-jest` as the shared Jest ESM-consumption reference for future runtime packages
+2. define the build output and export contract for `packages/api-contract` so generated source stops being the primary runtime surface
+3. migrate `packages/api-contract` after its build and consumer contract are documented, keeping it ESM-only unless a verified blocker requires a CommonJS path
+4. decide whether config packages should remain direct source-export tool packages or move to a separate built-distribution model before attempting any config-package ESM change
+5. revisit application runtime module strategy only after package-level migration rules are stable and proven in at least one additional runtime package
 
 ## Follow-up issue split
 
 The next implementation work should be split into discrete repository tasks:
 
-- add a shared Jest baseline for consuming explicit ESM workspace packages
 - define the build artifact and export contract for `packages/api-contract`
-- migrate `packages/api-contract` with dual-publish support if any consumer still requires CommonJS
+- migrate `packages/api-contract` as ESM-only unless an actual current consumer forces a retained CommonJS path
 - decide the long-term contract for config packages: direct source exports versus built distribution packages
 - audit API-side consumer compatibility before any package drops CommonJS support
 

--- a/packages/config-jest/README.md
+++ b/packages/config-jest/README.md
@@ -19,6 +19,13 @@ Typing rule:
 - app-level Jest config files should use `defineJestConfig` from this package instead of importing `@jest/types` directly
 - this keeps Jest config typing deterministic without making each app workspace own the low-level Jest type package
 
+ESM package support rule:
+
+- the shared baseline owns the default `transformIgnorePatterns` contract for `node_modules`
+- app-level Jest config files should use `withEsmPackageSupport` when they need to allow specific ESM packages through Jest transforms
+- `withEsmPackageSupport` can also merge `extensionsToTreatAsEsm` for toolchains that opt into Jest ESM execution
+- Node plus `ts-jest` consumers should pair `extensionsToTreatAsEsm` with a matching `useESM: true` transform decision in the app-level config
+
 The repository uses `ts-node` to load TypeScript-based Jest config files.
 
 The shared Jest baselines do not require `src` or `test` directories yet. Follow-up app issues can add tighter roots when real source trees exist.

--- a/packages/config-jest/base.ts
+++ b/packages/config-jest/base.ts
@@ -19,6 +19,7 @@ const config = defineJestConfig({
     '/generated/',
     '/__generated__/',
   ],
+  transformIgnorePatterns: ['/node_modules/'],
 });
 
 export default config;

--- a/packages/config-jest/define.ts
+++ b/packages/config-jest/define.ts
@@ -1,5 +1,69 @@
 import type { Config } from '@jest/types';
 
 export type JestConfig = Config.InitialOptions;
+export type EsmPackageSupportOptions = {
+	packageNames?: readonly string[];
+	extensionsToTreatAsEsm?: readonly string[];
+	extraTransformIgnorePatterns?: readonly string[];
+};
+
+const defaultNodeModulesTransformIgnorePattern = '/node_modules/';
 
 export const defineJestConfig = <T extends JestConfig>(config: T): T => config;
+
+function mergeUniqueStrings(...lists: ReadonlyArray<readonly string[] | undefined>): string[] {
+	const merged: string[] = [];
+
+	for (const list of lists) {
+		for (const value of list ?? []) {
+			if (!merged.includes(value)) {
+				merged.push(value);
+			}
+		}
+	}
+
+	return merged;
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
+}
+
+function isNodeModulesTransformIgnorePattern(pattern: string): boolean {
+	return pattern.includes('/node_modules/');
+}
+
+function createNodeModulesTransformIgnorePattern(packageNames: readonly string[]): string {
+	if (packageNames.length === 0) {
+		return defaultNodeModulesTransformIgnorePattern;
+	}
+
+	const alternation = packageNames.map(escapeRegExp).join('|');
+
+	return `/node_modules/(?!(?:${alternation})(?:/|$))/`;
+}
+
+export const withEsmPackageSupport = <T extends JestConfig>(
+	config: T,
+	options: EsmPackageSupportOptions = {},
+): T & JestConfig => {
+	const extensionsToTreatAsEsm = mergeUniqueStrings(
+		config.extensionsToTreatAsEsm,
+		options.extensionsToTreatAsEsm,
+	);
+	const transformIgnorePatterns = [
+		createNodeModulesTransformIgnorePattern(options.packageNames ?? []),
+		...mergeUniqueStrings(
+			(config.transformIgnorePatterns ?? []).filter(
+				(pattern): pattern is string => !isNodeModulesTransformIgnorePattern(pattern),
+			),
+			options.extraTransformIgnorePatterns,
+		),
+	];
+
+	return defineJestConfig({
+		...config,
+		...(extensionsToTreatAsEsm.length > 0 ? { extensionsToTreatAsEsm } : {}),
+		transformIgnorePatterns,
+	});
+};

--- a/packages/config-jest/define.ts
+++ b/packages/config-jest/define.ts
@@ -2,9 +2,9 @@ import type { Config } from '@jest/types';
 
 export type JestConfig = Config.InitialOptions;
 export type EsmPackageSupportOptions = {
-	packageNames?: readonly string[];
-	extensionsToTreatAsEsm?: readonly string[];
-	extraTransformIgnorePatterns?: readonly string[];
+  packageNames?: readonly string[];
+  extensionsToTreatAsEsm?: readonly string[];
+  extraTransformIgnorePatterns?: readonly string[];
 };
 
 const defaultNodeModulesTransformIgnorePattern = '/node_modules/';
@@ -12,58 +12,58 @@ const defaultNodeModulesTransformIgnorePattern = '/node_modules/';
 export const defineJestConfig = <T extends JestConfig>(config: T): T => config;
 
 function mergeUniqueStrings(...lists: ReadonlyArray<readonly string[] | undefined>): string[] {
-	const merged: string[] = [];
+  const merged: string[] = [];
 
-	for (const list of lists) {
-		for (const value of list ?? []) {
-			if (!merged.includes(value)) {
-				merged.push(value);
-			}
-		}
-	}
+  for (const list of lists) {
+    for (const value of list ?? []) {
+      if (!merged.includes(value)) {
+        merged.push(value);
+      }
+    }
+  }
 
-	return merged;
+  return merged;
 }
 
 function escapeRegExp(value: string): string {
-	return value.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
+  return value.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
 }
 
 function isNodeModulesTransformIgnorePattern(pattern: string): boolean {
-	return pattern.includes('/node_modules/');
+  return pattern.includes('/node_modules/');
 }
 
 function createNodeModulesTransformIgnorePattern(packageNames: readonly string[]): string {
-	if (packageNames.length === 0) {
-		return defaultNodeModulesTransformIgnorePattern;
-	}
+  if (packageNames.length === 0) {
+    return defaultNodeModulesTransformIgnorePattern;
+  }
 
-	const alternation = packageNames.map(escapeRegExp).join('|');
+  const alternation = packageNames.map(escapeRegExp).join('|');
 
-	return `/node_modules/(?!(?:${alternation})(?:/|$))/`;
+  return `/node_modules/(?!(?:${alternation})(?:/|$))/`;
 }
 
 export const withEsmPackageSupport = <T extends JestConfig>(
-	config: T,
-	options: EsmPackageSupportOptions = {},
+  config: T,
+  options: EsmPackageSupportOptions = {},
 ): T & JestConfig => {
-	const extensionsToTreatAsEsm = mergeUniqueStrings(
-		config.extensionsToTreatAsEsm,
-		options.extensionsToTreatAsEsm,
-	);
-	const transformIgnorePatterns = [
-		createNodeModulesTransformIgnorePattern(options.packageNames ?? []),
-		...mergeUniqueStrings(
-			(config.transformIgnorePatterns ?? []).filter(
-				(pattern): pattern is string => !isNodeModulesTransformIgnorePattern(pattern),
-			),
-			options.extraTransformIgnorePatterns,
-		),
-	];
+  const extensionsToTreatAsEsm = mergeUniqueStrings(
+    config.extensionsToTreatAsEsm,
+    options.extensionsToTreatAsEsm,
+  );
+  const transformIgnorePatterns = [
+    createNodeModulesTransformIgnorePattern(options.packageNames ?? []),
+    ...mergeUniqueStrings(
+      (config.transformIgnorePatterns ?? []).filter(
+        (pattern): pattern is string => !isNodeModulesTransformIgnorePattern(pattern),
+      ),
+      options.extraTransformIgnorePatterns,
+    ),
+  ];
 
-	return defineJestConfig({
-		...config,
-		...(extensionsToTreatAsEsm.length > 0 ? { extensionsToTreatAsEsm } : {}),
-		transformIgnorePatterns,
-	});
+  return defineJestConfig({
+    ...config,
+    ...(extensionsToTreatAsEsm.length > 0 ? { extensionsToTreatAsEsm } : {}),
+    transformIgnorePatterns,
+  });
 };


### PR DESCRIPTION
AI-generated PR for issue #141.

## Summary
- add shared Jest config support for allowlisting ESM packages under node_modules
- move the web Jest config to the shared ESM package support helper and add focused coverage for the helper behavior
- refresh the ESM migration strategy so runtime packages prefer ESM-only exports and Jest handling reflects the current shared baseline

## Validation
- /workspaces/focusbuddy/node_modules/.bin/jest --config /workspaces/focusbuddy/.worktrees/issue-141/apps/api/jest.config.ts --runInBand --runTestsByPath /workspaces/focusbuddy/.worktrees/issue-141/apps/api/test/config-jest-esm-support.spec.ts
- /workspaces/focusbuddy/node_modules/.bin/jest --config /workspaces/focusbuddy/.worktrees/issue-141/apps/web/jest.config.ts --runInBand --runTestsByPath /workspaces/focusbuddy/.worktrees/issue-141/apps/web/test/web-logging-demo.test.tsx

Closes #141
