### PR TITLE
chore: adopt ESM-first tooling policy

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -4,7 +4,9 @@
 
 set -euo pipefail
 
-expected_package_manager="$(node -p "require('./package.json').packageManager")"
+expected_package_manager="$({
+	node --input-type=module -e "import { readFileSync } from 'node:fs'; console.log(JSON.parse(readFileSync('./package.json', 'utf8')).packageManager);"
+})"
 
 node --version
 corepack --version

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-pnpm exec commitlint --config commitlint.config.cjs --edit "$1"
+pnpm exec commitlint --config commitlint.config.ts --edit "$1"

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,4 +1,6 @@
-module.exports = {
+import type { UserConfig } from '@commitlint/types';
+
+const config: UserConfig = {
   extends: ['@commitlint/config-conventional'],
   plugins: [
     {
@@ -21,3 +23,5 @@ module.exports = {
     'issue-reference-required': [2, 'always'],
   },
 };
+
+export default config;

--- a/docs/platform/esm-migration-strategy.md
+++ b/docs/platform/esm-migration-strategy.md
@@ -34,23 +34,18 @@ This document does not define a repository-wide app runtime conversion to pure E
 
 ## Current CommonJS exceptions
 
-The repository currently allows only these file-level CommonJS exceptions:
-
-| File | Why it remains CommonJS | Exit condition |
-| --- | --- | --- |
-| `prettier.config.cjs` | the repository root and generator tooling still rely on a stable CommonJS Prettier config path | remove once the root Prettier entry and all explicit callers are verified against an ESM config path |
-| `packages/config-prettier/index.cjs` | the shared Prettier config package currently publishes the CommonJS entry consumed by `prettier.config.cjs` | remove once the shared Prettier package can publish an ESM entry that all current callers load without compatibility issues |
+The repository currently has no documented file-level CommonJS exceptions.
 
 ## Package inventory and migration stance
 
 | Workspace | Current state | Migration stance | Notes |
 | --- | --- | --- | --- |
 | `packages/logger` | explicit ESM runtime package | keep as the repository's simplest runtime-package reference | uses `type: module`, explicit ESM export entrypoints, and TypeScript-emitted build artifacts |
-| `packages/api-contract` | explicit ESM runtime package with generated `.ts` source and built `.js` artifacts | continue tightening the build contract | should keep moving toward built-artifact-first consumption and currently still points generator formatting at the root CommonJS Prettier entry |
+| `packages/api-contract` | explicit ESM runtime package with generated `.ts` source and built `.js` artifacts | continue tightening the build contract | should keep moving toward built-artifact-first consumption and now points generator formatting at the root ESM Prettier entry |
 | `packages/config-typescript` | exports shared JSON config files | keep current mode for now | TypeScript config consumers do not benefit from package-level ESM and still depend on current tool loading behavior |
 | `packages/config-jest` | exports raw `.ts` config modules with a shared ESM-consumption helper | coordinated migration only | the shared baseline now owns `node_modules` allowlist rules for ESM package consumption, but the package itself still relies on TypeScript config loading and Jest-specific loader behavior |
 | `packages/config-oxlint` | exports raw `.ts` config modules | coordinated migration only | current consumers depend on tool execution of TypeScript config files |
-| `packages/config-prettier` | CommonJS-only `index.cjs` entry | keep CommonJS | Prettier config loading still requires a stable CommonJS path in this repository |
+| `packages/config-prettier` | explicit `.mjs` tool config package | keep as the shared Prettier reference | the repository root and the API contract generator both consume the ESM entry |
 | `apps/api` | NodeNext TypeScript app consumer | not a package-conversion target in this issue | app runtime strategy remains separate from package migration strategy |
 | `apps/web` | bundler-managed app consumer | not a package-conversion target in this issue | can consume ESM packages without forcing repository-wide package conversion |
 | `apps/mobile` | placeholder workspace | no action now | revisit when the workspace has real runtime code |
@@ -86,7 +81,7 @@ For this repository, the current Jest rule is:
 
 ### Tool-owned config packages
 
-The shared config packages currently export raw `.ts`, `.json`, and `.cjs` files that are consumed directly by TypeScript, Jest, oxlint, and Prettier tooling entrypoints.
+The shared config packages currently export raw `.ts`, `.json`, and `.mjs` files that are consumed directly by TypeScript, Jest, oxlint, and Prettier tooling entrypoints.
 
 Those packages should not be converted package-by-package without a coordinated loader decision because their consumers are tools, not normal runtime imports. A repository-wide loader break in config packages would block routine lint, test, and typecheck flows.
 
@@ -135,7 +130,6 @@ The next implementation work should be split into discrete repository tasks:
 - define the build artifact and export contract for `packages/api-contract`
 - migrate `packages/api-contract` as ESM-only unless an actual current consumer forces a retained CommonJS path
 - decide the long-term contract for config packages: direct source exports versus built distribution packages
-- verify and remove the remaining CommonJS Prettier exception chain when generator callers can consume an ESM config path
 - audit API-side consumer compatibility before any package drops CommonJS support
 
 ## Review trigger

--- a/docs/platform/esm-migration-strategy.md
+++ b/docs/platform/esm-migration-strategy.md
@@ -1,36 +1,52 @@
-# Package ESM Migration Strategy
+# Repository ESM Strategy
 
-This document captures the output of issue #120.
+This document captures the repository module strategy after issue #57 and the package migration work from issue #120.
 
-Its purpose is to define a repository-wide strategy for converting workspace packages to explicit ESM packages after the focused logger-package change from issue #23.
+Its purpose is to define an ESM-first repository policy, the file-level CommonJS exceptions that still remain, and the package contract for workspace packages that move to explicit ESM after the focused logger-package change from issue #23.
 
 ## Scope
 
 This document defines:
 
+- the repository default for hand-written JavaScript, TypeScript, and tool config files
+- which current files are allowed to remain CommonJS
 - which workspace packages are candidates for explicit ESM conversion
 - the package contract required before a package can declare `type: module`
-- where current tooling still assumes CommonJS-oriented behavior
-- when CommonJS compatibility must remain in place for packages that still need it
+- when CommonJS compatibility may remain in place for packages or config files that still need it
 - an ordered follow-up plan for package-by-package migration work
 
 This document does not define a repository-wide app runtime conversion to pure ESM.
 
 ## Decision rules
 
+- all hand-written JavaScript and TypeScript should be written in ESM form unless a documented exception still applies
+- tool config files should use ESM-compatible formats whenever the current toolchain supports them in a stable way
+- CommonJS is allowed only for a file whose current tool or invocation path is not yet verified as stable under ESM
+- CommonJS exceptions must be tracked file-by-file with both the current reason and the condition that would allow removal
+- new files must default to ESM and must not introduce new CommonJS entrypoints without a documented blocker
+- existing CommonJS files should be treated as temporary compatibility shims and removed once the blocker is verified gone
 - explicit ESM is opt-in per package; one package changing module mode does not authorize ad hoc conversion of unrelated packages
 - runtime packages that other workspaces import at runtime should prefer built artifact exports over raw source file exports before they become explicit ESM packages
 - runtime packages should default to explicit ESM-only exports and should add a CommonJS `require` path only when a verified current consumer or tool still blocks on it
-- config packages consumed directly by tools should not become explicit ESM packages until the consuming toolchain contract is documented and verified
-- a package must keep CommonJS compatibility whenever any current consumer or tool still relies on `require()` or a CommonJS-only loader path
+- config packages consumed directly by tools should not change module contracts until the consuming toolchain contract is documented and verified
+- a package or config file may keep CommonJS compatibility only while a verified current consumer or tool still relies on `require()` or a CommonJS-only loader path
 - no package may switch to explicit ESM without a documented export surface, build output contract, and verification plan
+
+## Current CommonJS exceptions
+
+The repository currently allows only these file-level CommonJS exceptions:
+
+| File | Why it remains CommonJS | Exit condition |
+| --- | --- | --- |
+| `prettier.config.cjs` | the repository root and generator tooling still rely on a stable CommonJS Prettier config path | remove once the root Prettier entry and all explicit callers are verified against an ESM config path |
+| `packages/config-prettier/index.cjs` | the shared Prettier config package currently publishes the CommonJS entry consumed by `prettier.config.cjs` | remove once the shared Prettier package can publish an ESM entry that all current callers load without compatibility issues |
 
 ## Package inventory and migration stance
 
 | Workspace | Current state | Migration stance | Notes |
 | --- | --- | --- | --- |
 | `packages/logger` | explicit ESM runtime package | keep as the repository's simplest runtime-package reference | uses `type: module`, explicit ESM export entrypoints, and TypeScript-emitted build artifacts |
-| `packages/api-contract` | source-export package with generated `.ts` outputs and a CommonJS helper entry | next runtime package candidate after a build contract is defined | should not expose generated source files as the long-term runtime contract once it becomes explicit ESM |
+| `packages/api-contract` | explicit ESM runtime package with generated `.ts` source and built `.js` artifacts | continue tightening the build contract | should keep moving toward built-artifact-first consumption and currently still points generator formatting at the root CommonJS Prettier entry |
 | `packages/config-typescript` | exports shared JSON config files | keep current mode for now | TypeScript config consumers do not benefit from package-level ESM and still depend on current tool loading behavior |
 | `packages/config-jest` | exports raw `.ts` config modules with a shared ESM-consumption helper | coordinated migration only | the shared baseline now owns `node_modules` allowlist rules for ESM package consumption, but the package itself still relies on TypeScript config loading and Jest-specific loader behavior |
 | `packages/config-oxlint` | exports raw `.ts` config modules | coordinated migration only | current consumers depend on tool execution of TypeScript config files |
@@ -74,6 +90,12 @@ The shared config packages currently export raw `.ts`, `.json`, and `.cjs` files
 
 Those packages should not be converted package-by-package without a coordinated loader decision because their consumers are tools, not normal runtime imports. A repository-wide loader break in config packages would block routine lint, test, and typecheck flows.
 
+The repository default is still ESM-first for tool configs. The current rule is:
+
+- prefer `.ts`, `.mts`, `.mjs`, or other ESM-compatible config formats when the tool documents stable support
+- keep a CommonJS config only when the exact current invocation path is still unverified or unstable under ESM
+- document each remaining CommonJS file in the exception table above instead of treating config packages as blanket CommonJS-only areas
+
 ### API runtime compatibility
 
 The API workspace uses the NodeNext TypeScript baseline with NestJS-oriented compiler settings. That is compatible with consuming explicit ESM packages through a stable export contract, but it does not by itself justify converting the API app runtime to pure ESM.
@@ -88,12 +110,13 @@ The repository build and test tasks rely on upstream workspace builds through Tu
 
 - runtime libraries with a narrow public API and an explicit build output can migrate individually once they adopt the full package contract
 - packages whose current consumers are already ESM-compatible can follow the logger package's ESM-only pattern in separate implementation issues
+- root tool configs such as commitlint and stylelint should move to ESM-compatible file formats as soon as their current command paths are verified
 
 ## What must be coordinated across the repository
 
 - any change to `packages/config-jest`, `packages/config-oxlint`, `packages/config-typescript`, or `packages/config-prettier`
 - any change that requires the shared Jest baseline to adopt repository-wide ESM handling rules
-- any change that removes CommonJS compatibility from a package still consumed by existing Node or tool entrypoints
+- any change that removes CommonJS compatibility from a package or config file still consumed by existing Node or tool entrypoints
 - any change that couples package migration with an application runtime module-strategy change
 
 ## Ordered follow-up plan
@@ -101,8 +124,9 @@ The repository build and test tasks rely on upstream workspace builds through Tu
 1. keep `packages/logger` as the ESM-only runtime reference and `packages/config-jest` as the shared Jest ESM-consumption reference for future runtime packages
 2. define the build output and export contract for `packages/api-contract` so generated source stops being the primary runtime surface
 3. migrate `packages/api-contract` after its build and consumer contract are documented, keeping it ESM-only unless a verified blocker requires a CommonJS path
-4. decide whether config packages should remain direct source-export tool packages or move to a separate built-distribution model before attempting any config-package ESM change
-5. revisit application runtime module strategy only after package-level migration rules are stable and proven in at least one additional runtime package
+4. keep converting root tool configs to ESM-compatible formats when their current invocations are verified, and keep the CommonJS exception list as small as possible
+5. decide whether config packages should remain direct source-export tool packages or move to a separate built-distribution model before attempting any coordinated config-package module-contract change
+6. revisit application runtime module strategy only after package-level migration rules are stable and proven in at least one additional runtime package
 
 ## Follow-up issue split
 
@@ -111,6 +135,7 @@ The next implementation work should be split into discrete repository tasks:
 - define the build artifact and export contract for `packages/api-contract`
 - migrate `packages/api-contract` as ESM-only unless an actual current consumer forces a retained CommonJS path
 - decide the long-term contract for config packages: direct source exports versus built distribution packages
+- verify and remove the remaining CommonJS Prettier exception chain when generator callers can consume an ESM config path
 - audit API-side consumer compatibility before any package drops CommonJS support
 
 ## Review trigger

--- a/docs/platform/shared-tooling.md
+++ b/docs/platform/shared-tooling.md
@@ -36,9 +36,9 @@ This document does not define application code, end-to-end test strategy, or dep
 
 ### `packages/config-prettier`
 
-- `index.cjs` is the single source of truth for formatting decisions
+- `index.mjs` is the single source of truth for formatting decisions
 - quote style is defined here so style comments do not need to be repeated in reviews
-- this package is currently a documented CommonJS exception and should move only after the root Prettier entry and generator callers can consume an ESM config path safely
+- the repository root consumes this package through `prettier.config.mjs`
 
 ### `packages/config-jest`
 

--- a/docs/platform/shared-tooling.md
+++ b/docs/platform/shared-tooling.md
@@ -38,6 +38,7 @@ This document does not define application code, end-to-end test strategy, or dep
 
 - `index.cjs` is the single source of truth for formatting decisions
 - quote style is defined here so style comments do not need to be repeated in reviews
+- this package is currently a documented CommonJS exception and should move only after the root Prettier entry and generator callers can consume an ESM config path safely
 
 ### `packages/config-jest`
 
@@ -75,6 +76,8 @@ The repository now uses GitHub Actions to run the same merge gate on pull reques
 Deploy-only checks remain outside this merge gate. Examples include deployed acceptance checks, deploy approval rules, and runtime-only validation in non-local environments.
 
 The repository-wide package ESM migration strategy is documented in `docs/platform/esm-migration-strategy.md` and must be consulted before converting additional workspace packages to explicit ESM.
+
+The repository default for hand-written JavaScript, TypeScript, and tool config files is now ESM-first. Remaining CommonJS files must be tracked as explicit file-level exceptions in that strategy document.
 
 ## Generated files rule
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
+    "@commitlint/types": "^20.0.0",
     "husky": "^9.1.7",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
-    "@commitlint/types": "^20.0.0",
+    "@commitlint/types": "^20.5.0",
     "husky": "^9.1.7",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",

--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -25,7 +25,7 @@
     "clean:generated": "rm -rf ./generated && mkdir -p ./generated",
     "dev": "pnpm generate",
     "generate": "pnpm clean:generated && pnpm generate:types && pnpm generate:client",
-    "generate:client": "openapi-zod-client ./openapi/focusbuddy.openapi.yaml -o ./generated/client.ts --export-schemas -p ../../prettier.config.cjs",
+    "generate:client": "openapi-zod-client ./openapi/focusbuddy.openapi.yaml -o ./generated/client.ts --export-schemas -p ../../prettier.config.mjs",
     "generate:types": "openapi-typescript ./openapi/focusbuddy.openapi.yaml -o ./generated/types.ts",
     "lint": "pnpm --dir ../.. exec oxlint packages/api-contract",
     "test": "pnpm build && node --test ./test/*.test.mjs",

--- a/packages/config-prettier/README.md
+++ b/packages/config-prettier/README.md
@@ -2,6 +2,6 @@
 
 This package provides the shared Prettier baseline for the FocusBuddy monorepo.
 
-The repository root uses this package through `prettier.config.cjs`.
+The repository root uses this package through `prettier.config.mjs`.
 
 The shared config is the single source of truth for formatting details such as quote style.

--- a/packages/config-prettier/index.mjs
+++ b/packages/config-prettier/index.mjs
@@ -1,7 +1,9 @@
-module.exports = {
+const config = {
   printWidth: 100,
   semi: true,
   singleQuote: true,
   trailingComma: 'all',
   proseWrap: 'preserve',
 };
+
+export default config;

--- a/packages/config-prettier/package.json
+++ b/packages/config-prettier/package.json
@@ -2,12 +2,12 @@
   "name": "@focusbuddy/config-prettier",
   "private": true,
   "version": "0.0.0",
-  "main": "index.cjs",
+  "main": "index.mjs",
   "files": [
-    "index.cjs"
+    "index.mjs"
   ],
   "exports": {
-    ".": "./index.cjs"
+    ".": "./index.mjs"
   },
   "scripts": {
     "build": "node ../../scripts/workspace-task.mjs @focusbuddy/config-prettier build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         specifier: ^20.5.0
         version: 20.5.0
       '@commitlint/types':
-        specifier: ^20.0.0
+        specifier: ^20.5.0
         version: 20.5.0
       husky:
         specifier: ^9.1.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^20.5.0
         version: 20.5.0
+      '@commitlint/types':
+        specifier: ^20.0.0
+        version: 20.5.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,1 +1,0 @@
-module.exports = require('./packages/config-prettier');

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,0 +1,1 @@
+export { default } from './packages/config-prettier/index.mjs';

--- a/scripts/demo-commitlint.mjs
+++ b/scripts/demo-commitlint.mjs
@@ -21,7 +21,7 @@ const scenarios = [
 let hasFailure = false;
 
 for (const scenario of scenarios) {
-  const result = spawnSync('pnpm', ['exec', 'commitlint', '--config', 'commitlint.config.cjs'], {
+  const result = spawnSync('pnpm', ['exec', 'commitlint', '--config', 'commitlint.config.ts'], {
     cwd: process.cwd(),
     encoding: 'utf8',
     input: scenario.message,

--- a/scripts/verify-setup.mjs
+++ b/scripts/verify-setup.mjs
@@ -4,12 +4,12 @@ import { resolve } from 'node:path';
 
 const failures = [];
 
-const commitlintConfigPath = resolve(process.cwd(), 'commitlint.config.cjs');
+const commitlintConfigPath = resolve(process.cwd(), 'commitlint.config.ts');
 const commitMsgHookPath = resolve(process.cwd(), '.husky/commit-msg');
 const huskyRuntimePath = resolve(process.cwd(), '.husky/_');
 
 if (!existsSync(commitlintConfigPath)) {
-  failures.push('commitlint.config.cjs is missing');
+  failures.push('commitlint.config.ts is missing');
 }
 
 if (!existsSync(commitMsgHookPath)) {
@@ -37,7 +37,7 @@ if (hooksPath.status !== 0 || hooksPath.stdout.trim() !== '.husky/_') {
 
 const validSmokeTest = spawnSync(
   'pnpm',
-  ['exec', 'commitlint', '--config', 'commitlint.config.cjs'],
+  ['exec', 'commitlint', '--config', 'commitlint.config.ts'],
   {
     cwd: process.cwd(),
     encoding: 'utf8',
@@ -51,7 +51,7 @@ if (validSmokeTest.status !== 0) {
 
 const invalidSmokeTest = spawnSync(
   'pnpm',
-  ['exec', 'commitlint', '--config', 'commitlint.config.cjs'],
+  ['exec', 'commitlint', '--config', 'commitlint.config.ts'],
   {
     cwd: process.cwd(),
     encoding: 'utf8',

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   extends: ['stylelint-config-standard'],
   ignoreFiles: ['**/.next/**', '**/coverage/**', '**/node_modules/**'],
   rules: {

--- a/test/commitlint.test.mjs
+++ b/test/commitlint.test.mjs
@@ -10,7 +10,7 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 function runCommitlint(message) {
   return new Promise((resolveResult, reject) => {
-    const child = spawn('pnpm', ['exec', 'commitlint', '--config', 'commitlint.config.cjs'], {
+    const child = spawn('pnpm', ['exec', 'commitlint', '--config', 'commitlint.config.ts'], {
       cwd: repoRoot,
       stdio: ['pipe', 'pipe', 'pipe'],
     });


### PR DESCRIPTION
AI agent created this PR.

## Summary
- document an ESM-first repository policy and remove the remaining documented CJS exceptions
- move commitlint, stylelint, and Prettier config entrypoints to ESM-compatible formats
- remove the final CommonJS runtime usage from devcontainer setup and align the lockfile for CI

## Validation
- node scripts/verify-setup.mjs
- node --test test/commitlint.test.mjs
- pnpm exec stylelint "apps/web/src/**/*.css"
- pnpm exec prettier --check README.md
- pnpm --filter @focusbuddy/api-contract generate
- pnpm install --frozen-lockfile