### PR TITLE
Stop consuming shared tooling configs through package entrypoints

### DIFF
--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -1,8 +1,8 @@
 /** @jest-config-loader ts-node */
 /** @jest-config-loader-options {"transpileOnly": true} */
 
-import { defineJestConfig } from '../../packages/config-jest/define.ts';
-import sharedConfig from '../../packages/config-jest/api.ts';
+import { defineJestConfig } from '@focusbuddy/config-jest/define';
+import sharedConfig from '@focusbuddy/config-jest/api';
 
 const config = defineJestConfig({
   ...sharedConfig,

--- a/apps/api/oxlint.config.ts
+++ b/apps/api/oxlint.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'oxlint';
-import apiConfig from '../../packages/config-oxlint/api/oxlint.config.ts';
+import apiConfig from '@focusbuddy/config-oxlint/api';
 
 export default defineConfig({
   extends: [apiConfig],

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -31,6 +31,9 @@
     "rxjs": "^7.8.2"
   },
   "devDependencies": {
+    "@focusbuddy/config-jest": "workspace:*",
+    "@focusbuddy/config-oxlint": "workspace:*",
+    "@focusbuddy/config-typescript": "workspace:*",
     "@nestjs/cli": "^11.0.18",
     "@nestjs/testing": "^11.1.18",
     "@types/jest": "^30.0.0",

--- a/apps/api/test/config-jest-esm-support.spec.ts
+++ b/apps/api/test/config-jest-esm-support.spec.ts
@@ -1,4 +1,4 @@
-import { defineJestConfig, withEsmPackageSupport } from '../../../packages/config-jest/define.ts'
+import { defineJestConfig, withEsmPackageSupport } from '@focusbuddy/config-jest/define'
 
 describe('withEsmPackageSupport', () => {
   it('replaces the node_modules ignore pattern with one allowlist pattern', () => {

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "../../packages/config-typescript/api.json",
+  "extends": "@focusbuddy/config-typescript/api",
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -3,8 +3,8 @@
 
 import nextJest from 'next/jest.js';
 
-import { defineJestConfig, withEsmPackageSupport } from '../../packages/config-jest/define.ts';
-import sharedConfig from '../../packages/config-jest/web.ts';
+import { defineJestConfig, withEsmPackageSupport } from '@focusbuddy/config-jest/define';
+import sharedConfig from '@focusbuddy/config-jest/web';
 
 const createJestConfig = nextJest({ dir: './apps/web' });
 

--- a/apps/web/oxlint.config.ts
+++ b/apps/web/oxlint.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'oxlint';
-import webConfig from '../../packages/config-oxlint/web/oxlint.config.ts';
+import webConfig from '@focusbuddy/config-oxlint/web';
 
 export default defineConfig({
   extends: [webConfig],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,9 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
+    "@focusbuddy/config-jest": "workspace:*",
+    "@focusbuddy/config-oxlint": "workspace:*",
+    "@focusbuddy/config-typescript": "workspace:*",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/jest": "^30.0.0",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "../../packages/config-typescript/web.json",
+  "extends": "@focusbuddy/config-typescript/web",
   "compilerOptions": {
     "allowJs": false,
     "incremental": true,

--- a/docs/platform/monorepo-workspace.md
+++ b/docs/platform/monorepo-workspace.md
@@ -88,6 +88,7 @@ packages/
 
 - app code lives under `apps/*`
 - shared reusable code or configuration lives under `packages/*`
+- app workspaces must consume code and config from `packages/*` through package names and exported entrypoints, not through relative filesystem paths into package internals
 - API contract ownership starts in `packages/api-contract`, not in the API app
 - Prisma and database access stay in the API boundary unless a later issue explicitly extracts a shared database package
 - generated contract outputs are expected to be consumed by apps, not edited manually inside apps

--- a/docs/platform/shared-tooling.md
+++ b/docs/platform/shared-tooling.md
@@ -51,6 +51,14 @@ This document does not define application code, end-to-end test strategy, or dep
 - the shared Jest baselines stay directory-agnostic until the real app source trees exist in follow-up issues
 - the shared Jest baselines do not enable TypeScript test execution until a real transform is chosen in follow-up app work
 
+## Shared config consumption rule
+
+- app workspaces must consume shared config packages through package names and exported subpaths such as `@focusbuddy/config-jest/web`
+- app workspaces must not reach into `packages/*` through relative filesystem paths such as `../../packages/config-jest/...`
+- when an app-level config or test file imports a shared config package, that app must declare the package in its own `devDependencies`
+- this rule also applies to TypeScript config inheritance when the shared config package exposes a stable package subpath
+- root-owned tool executables such as `jest`, `oxlint`, `ts-node`, and `stylelint` may stay at the repository root when package scripts intentionally invoke them through repository-owned command entrypoints
+
 ## Repository commands
 
 The repository root now exposes:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,15 @@ importers:
         specifier: ^7.8.2
         version: 7.8.2
     devDependencies:
+      '@focusbuddy/config-jest':
+        specifier: workspace:*
+        version: link:../../packages/config-jest
+      '@focusbuddy/config-oxlint':
+        specifier: workspace:*
+        version: link:../../packages/config-oxlint
+      '@focusbuddy/config-typescript':
+        specifier: workspace:*
+        version: link:../../packages/config-typescript
       '@nestjs/cli':
         specifier: ^11.0.18
         version: 11.0.18(@types/node@25.5.2)
@@ -135,6 +144,15 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
     devDependencies:
+      '@focusbuddy/config-jest':
+        specifier: workspace:*
+        version: link:../../packages/config-jest
+      '@focusbuddy/config-oxlint':
+        specifier: workspace:*
+        version: link:../../packages/config-oxlint
+      '@focusbuddy/config-typescript':
+        specifier: workspace:*
+        version: link:../../packages/config-typescript
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1


### PR DESCRIPTION
AIエージェント作成 PR

## Summary
- switch app-level Jest, oxlint, and TypeScript config consumption from relative paths into package entrypoints
- declare shared config packages in app devDependencies and refresh the lockfile
- document the coding rule that apps must not reach into packages/* through relative filesystem paths

## Commits
- refactor: consume shared config packages in apps refs #149
- docs: codify shared config package consumption refs #149

## Testing
- pnpm merge-gate

## Related
- closes #149
