### PR TITLE
feat(api): add shared #api module resolution contract

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -17,3 +17,5 @@ This workspace now contains the first NestJS API baseline for issue #21.
 - Prisma CLI uses `prisma.config.ts`, while runtime access uses the PostgreSQL driver adapter required by Prisma 7
 
 The API workspace depends on `@focusbuddy/api-contract` and expects its generated outputs to be built before local compile or test commands run.
+
+The current repository-owned module resolution contract for this workspace is documented in `docs/platform/api-module-resolution-contract.md`.

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -18,4 +18,4 @@ This workspace now contains the first NestJS API baseline for issue #21.
 
 The API workspace depends on `@focusbuddy/api-contract` and expects its generated outputs to be built before local compile or test commands run.
 
-The current repository-owned module resolution contract for this workspace is documented in `docs/platform/api-module-resolution-contract.md`.
+The current repository-owned module resolution contract for this workspace uses `#api/*` for app-local imports and is documented in `docs/platform/api-module-resolution-contract.md`.

--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -6,6 +6,9 @@ import sharedConfig from '@focusbuddy/config-jest/api';
 
 const config = defineJestConfig({
   ...sharedConfig,
+  moduleNameMapper: {
+    '^#api/(.*)$': '<rootDir>/src/$1',
+  },
   moduleFileExtensions: [...(sharedConfig.moduleFileExtensions ?? []), 'ts'],
   roots: ['<rootDir>/src', '<rootDir>/test'],
   testMatch: ['<rootDir>/test/**/*.spec.ts'],

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,17 +3,24 @@
   "private": true,
   "version": "0.0.0",
   "main": "dist/main.js",
+  "imports": {
+    "#api/*": {
+      "types": "./src/*.ts",
+      "development": "./src/*.ts",
+      "default": "./dist/*.js"
+    }
+  },
   "scripts": {
     "build": "pnpm contract:build && pnpm logger:build && pnpm prisma:generate && pnpm --dir ../.. exec tsc --project apps/api/tsconfig.build.json",
     "contract:build": "pnpm --dir ../.. --filter @focusbuddy/api-contract build",
-    "dev": "pnpm contract:build && pnpm logger:build && pnpm prisma:generate && pnpm exec nest start --watch",
+    "dev": "pnpm contract:build && pnpm logger:build && pnpm prisma:generate && NODE_OPTIONS=--conditions=development pnpm exec tsx watch src/main.ts",
     "logger:build": "pnpm --dir ../.. --filter @focusbuddy/logger build",
     "lint": "pnpm --dir ../.. exec oxlint apps/api/src apps/api/test apps/api/prisma",
     "parity": "pnpm build && node dist/main.js",
-    "prisma:generate": "prisma generate --config prisma.config.ts",
-    "prisma:migrate:dev": "prisma migrate dev --config prisma.config.ts",
-    "prisma:studio": "prisma studio --config prisma.config.ts",
-    "test": "pnpm contract:build && pnpm logger:build && pnpm prisma:generate && pnpm --dir ../.. exec jest --config apps/api/jest.config.ts --runInBand",
+    "prisma:generate": "NODE_OPTIONS=--conditions=development prisma generate --config prisma.config.ts",
+    "prisma:migrate:dev": "NODE_OPTIONS=--conditions=development prisma migrate dev --config prisma.config.ts",
+    "prisma:studio": "NODE_OPTIONS=--conditions=development prisma studio --config prisma.config.ts",
+    "test": "pnpm contract:build && pnpm logger:build && pnpm prisma:generate && NODE_OPTIONS=--conditions=development pnpm --dir ../.. exec jest --config apps/api/jest.config.ts --runInBand",
     "typecheck": "pnpm contract:build && pnpm logger:build && pnpm prisma:generate && pnpm --dir ../.. exec tsc --project apps/api/tsconfig.build.json --noEmit"
   },
   "dependencies": {
@@ -39,6 +46,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^25.5.2",
     "prisma": "^7.7.0",
+    "tsx": "^4.20.6",
     "ts-jest": "^29.4.9",
     "typescript": "^6.0.2"
   }

--- a/apps/api/prisma.config.ts
+++ b/apps/api/prisma.config.ts
@@ -4,7 +4,7 @@ import {
   buildDatabaseUrlRequirementMessage,
   loadLocalRuntimeEnv,
   resolveLocalRuntimeDatabaseUrl,
-} from './src/config/local-runtime-env';
+} from '#api/config/local-runtime-env';
 
 loadLocalRuntimeEnv(process.env, { cwd: __dirname });
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 
-import { HealthModule } from './health/health.module';
-import { PrismaModule } from './prisma/prisma.module';
+import { HealthModule } from '#api/health/health.module';
+import { PrismaModule } from '#api/prisma/prisma.module';
 
 @Module({
   imports: [PrismaModule, HealthModule],

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get } from '@nestjs/common';
 
-import { PrismaService } from '../prisma/prisma.service';
+import { PrismaService } from '#api/prisma/prisma.service';
 
 type HealthResponse = {
   status: 'ok';

--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 
-import { PrismaModule } from '../prisma/prisma.module';
-import { HealthController } from './health.controller';
+import { HealthController } from '#api/health/health.controller';
+import { PrismaModule } from '#api/prisma/prisma.module';
 
 @Module({
   imports: [PrismaModule],

--- a/apps/api/src/logging/api-request-logger.example.ts
+++ b/apps/api/src/logging/api-request-logger.example.ts
@@ -5,7 +5,7 @@ import {
   type RequestLogContext,
   type UserLogContext,
 } from '@focusbuddy/logger'
-import { apiRuntimeLogger } from './api-runtime-logger'
+import { apiRuntimeLogger } from '#api/logging/api-runtime-logger'
 
 const apiLogger = apiRuntimeLogger
 

--- a/apps/api/src/logging/api-request-logging.interceptor.ts
+++ b/apps/api/src/logging/api-request-logging.interceptor.ts
@@ -3,7 +3,7 @@ import type { Logger } from '@focusbuddy/logger';
 import { focusbuddyRequestIdHeader, focusbuddyTraceIdHeader } from '@focusbuddy/logger';
 import { Observable, tap } from 'rxjs';
 
-import { logApiRequestHandled } from './api-request-logger.example';
+import { logApiRequestHandled } from '#api/logging/api-request-logger.example';
 
 type ApiRequestLike = {
   headers: Record<string, string | string[] | undefined>;

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,10 +2,10 @@ import * as reflectMetadata from 'reflect-metadata';
 
 import { NestFactory } from '@nestjs/core';
 
-import { AppModule } from './app.module';
-import { loadLocalRuntimeEnv } from './config/local-runtime-env';
-import { ApiRequestLoggingInterceptor } from './logging/api-request-logging.interceptor';
-import { createApiRuntimeLogger } from './logging/api-runtime-logger';
+import { AppModule } from '#api/app.module';
+import { loadLocalRuntimeEnv } from '#api/config/local-runtime-env';
+import { ApiRequestLoggingInterceptor } from '#api/logging/api-request-logging.interceptor';
+import { createApiRuntimeLogger } from '#api/logging/api-runtime-logger';
 
 async function bootstrap(): Promise<void> {
   void reflectMetadata;

--- a/apps/api/src/prisma/prisma.module.ts
+++ b/apps/api/src/prisma/prisma.module.ts
@@ -1,6 +1,6 @@
 import { Global, Module } from '@nestjs/common';
 
-import { PrismaService } from './prisma.service';
+import { PrismaService } from '#api/prisma/prisma.service';
 
 @Global()
 @Module({

--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -2,7 +2,7 @@ import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { PrismaClient } from '@prisma/client';
 
-import { getRequiredDatabaseUrl, loadLocalRuntimeEnv } from '../config/local-runtime-env';
+import { getRequiredDatabaseUrl, loadLocalRuntimeEnv } from '#api/config/local-runtime-env';
 
 function createPrismaClientOptions(): ConstructorParameters<typeof PrismaClient>[0] {
   loadLocalRuntimeEnv();

--- a/apps/api/test/api-request-logger.spec.ts
+++ b/apps/api/test/api-request-logger.spec.ts
@@ -26,7 +26,7 @@ jest.mock('@focusbuddy/logger', () => {
   }
 })
 
-jest.mock('../src/logging/api-runtime-logger', () => {
+jest.mock('#api/logging/api-runtime-logger', () => {
   const noOpLogger = {
     child() {
       return noOpLogger
@@ -42,7 +42,7 @@ jest.mock('../src/logging/api-runtime-logger', () => {
 import {
   createApiRequestLogger,
   logApiRequestHandled,
-} from '../src/logging/api-request-logger.example'
+} from '#api/logging/api-request-logger.example'
 
 type RecordedEntry = {
   application?: string

--- a/apps/api/test/api-request-logging.interceptor.spec.ts
+++ b/apps/api/test/api-request-logging.interceptor.spec.ts
@@ -8,15 +8,15 @@ jest.mock('@focusbuddy/logger', () => ({
 
 const logApiRequestHandled = jest.fn()
 
-jest.mock('../src/logging/api-request-logger.example', () => ({
+jest.mock('#api/logging/api-request-logger.example', () => ({
   logApiRequestHandled: (...args: unknown[]) => logApiRequestHandled(...args),
 }))
 
-jest.mock('../src/logging/api-runtime-logger', () => ({
+jest.mock('#api/logging/api-runtime-logger', () => ({
   apiRuntimeLogger: {},
 }))
 
-import { ApiRequestLoggingInterceptor } from '../src/logging/api-request-logging.interceptor';
+import { ApiRequestLoggingInterceptor } from '#api/logging/api-request-logging.interceptor';
 
 describe('ApiRequestLoggingInterceptor', () => {
   it('binds correlation headers and emits a handled request event', async () => {

--- a/apps/api/test/contract-mappers.spec.ts
+++ b/apps/api/test/contract-mappers.spec.ts
@@ -1,6 +1,6 @@
 import { NoteVisibility, SessionVisibility, TargetSourceType } from '@prisma/client';
 
-import { mapPrismaFocusSessionToContract, mapPrismaFocusTargetToContract } from '../src/contracts/contract-mappers';
+import { mapPrismaFocusSessionToContract, mapPrismaFocusTargetToContract } from '#api/contracts/contract-mappers';
 
 describe('contract mappers', () => {
   it('maps a Prisma focus target into the generated contract shape', () => {

--- a/apps/api/test/health.controller.spec.ts
+++ b/apps/api/test/health.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test } from '@nestjs/testing';
 
-import { HealthController } from '../src/health/health.controller';
-import { PrismaService } from '../src/prisma/prisma.service';
+import { HealthController } from '#api/health/health.controller';
+import { PrismaService } from '#api/prisma/prisma.service';
 
 type PrismaProbe = {
   $queryRaw: (query: TemplateStringsArray) => Promise<unknown>;

--- a/apps/api/test/local-runtime-env.spec.ts
+++ b/apps/api/test/local-runtime-env.spec.ts
@@ -8,7 +8,7 @@ import {
   loadLocalRuntimeEnv,
   resolveTrackedDotenvPath,
   resolveLocalRuntimeDatabaseUrl,
-} from '../src/config/local-runtime-env';
+} from '#api/config/local-runtime-env';
 
 describe('local runtime env contract', () => {
   it('keeps an explicit DATABASE_URL unchanged', () => {

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@focusbuddy/config-typescript/api",
   "compilerOptions": {
+    "customConditions": ["development"],
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "isolatedModules": true

--- a/docs/platform/api-module-resolution-contract.md
+++ b/docs/platform/api-module-resolution-contract.md
@@ -20,37 +20,37 @@ This document does not define a repository-wide alias rollout, a package-boundar
 
 The current supported module resolution contract for `apps/api` is:
 
-- app-local imports stay relative-import-first
+- app-local imports use `#api/*` as the repository-owned internal specifier rooted at `apps/api`
 - workspace package imports use declared package names and exported subpaths only
 - external dependencies use their published package specifiers only
-- no app-local source alias such as `@/`, `~/`, or bare `src/*` is part of the supported API contract today
+- app-local runtime code, tests, and Prisma config all resolve the same `#api/*` specifier family
 
-This contract is intentionally conservative because it is the one contract shape that already aligns with the API workspace's current execution paths without adding separate runtime-specific resolution shims.
+This contract is intentionally narrow. `apps/api` owns one internal specifier family and wires every execution path to the same meaning instead of allowing tool-specific aliases to drift.
 
 ## Supported specifier forms
 
 ### App-local runtime code under `apps/api/src`
 
-Use relative specifiers for app-local code.
+Use `#api/*` for app-local code.
 
 Examples:
 
-- `./health/health.module`
-- `../config/local-runtime-env`
-- `./prisma.service`
+- `#api/health/health.module`
+- `#api/config/local-runtime-env`
+- `#api/prisma/prisma.service`
 
 Current hand-written API source intentionally uses this pattern in runtime entrypoints, modules, services, and adapters.
 
 ### API test files under `apps/api/test`
 
-Use relative specifiers into `../src/*` for API source imports from tests.
+Use the same `#api/*` specifiers for API source imports from tests.
 
 Examples:
 
-- `../src/health/health.controller`
-- `../src/logging/api-request-logging.interceptor`
+- `#api/health/health.controller`
+- `#api/logging/api-request-logging.interceptor`
 
-This matches the current `ts-jest` contract and avoids introducing a test-only alias rule that the runtime paths do not also own.
+This keeps Jest on the same import vocabulary as the runtime paths.
 
 ### Workspace package imports
 
@@ -66,13 +66,13 @@ This follows the repository-wide workspace boundary rules.
 
 ### Prisma config imports
 
-Use relative imports from `prisma.config.ts` into API runtime helpers under `./src/*`.
+Use the same `#api/*` imports from `prisma.config.ts` into API runtime helpers.
 
 Example:
 
-- `./src/config/local-runtime-env`
+- `#api/config/local-runtime-env`
 
-This keeps the Prisma CLI path aligned with the API source tree without inventing a separate config-only alias contract.
+This keeps the Prisma CLI path aligned with the same app-local contract used by compile, source startup, tests, and emitted runtime.
 
 ## Execution-path contract
 
@@ -82,15 +82,21 @@ This keeps the Prisma CLI path aligned with the API source tree without inventin
 
 The current repository-owned compile-time contract is:
 
-- relative app-local imports inside `src` and `test`
+- `#api/*` app-local imports inside `src`, `test`, and `prisma.config.ts`
 - declared package imports for workspace packages and external dependencies
-- no repository-owned app-local `paths` mapping for API source aliases
+- `package.json#imports` as the runtime contract plus `customConditions: ["development"]` for source-side resolution
 
 ### Nest local startup
 
-The API local dev command uses Nest startup against the hand-written TypeScript source tree.
+The API local dev command boots the Nest application directly from the hand-written TypeScript source tree.
 
-The supported contract for that path is still the same relative-import-first source layout. No additional alias loader, runtime import hook, or Nest-only resolution override is currently part of the supported API startup contract.
+The supported contract for that path is:
+
+- `NODE_OPTIONS=--conditions=development`
+- `tsx` executes `src/main.ts`
+- `#api/*` resolves to `./src/*.ts` through the package `imports` contract
+
+The repository explicitly does not rely on a Nest-only alias hook. Source startup uses the same package `imports` contract as the other paths and only swaps the TypeScript executor.
 
 ### Emitted runtime execution from `dist`
 
@@ -98,39 +104,41 @@ The parity and built-runtime path executes the emitted output from `dist/main.js
 
 The supported contract for that path is:
 
-- TypeScript emits runtime-relative module references that remain valid after the `src` tree is built into `dist`
-- runtime resolution does not depend on TypeScript-only alias metadata surviving into Node execution
+- TypeScript preserves `#api/*` specifiers in emitted output
+- Node resolves the same `#api/*` specifiers through package `imports`
+- the default package `imports` target resolves those specifiers to `./dist/*.js`
 
-This is one reason the current app-local contract stays relative-import-first.
+This is one reason the contract is owned in `package.json#imports` rather than in TypeScript-only `paths` metadata.
 
 ### Jest execution
 
-The API workspace uses `ts-jest` with the local TypeScript config and does not currently opt into a separate API alias contract.
+The API workspace uses `ts-jest` with the local TypeScript config and a Jest mapper for `#api/*`.
 
 The supported test-resolution contract is:
 
-- tests import source through relative paths into `../src/*`
+- tests import API source through `#api/*`
 - package imports keep using package names
-- Jest does not own a separate app-local alias mapping for API source files today
+- Jest mirrors the same repository-owned `#api/*` contract instead of inventing a different test-only vocabulary
 
 ### Prisma command execution
 
-The Prisma CLI path is configured through `apps/api/prisma.config.ts`, which imports API runtime env helpers from the source tree.
+The Prisma CLI path is configured through `apps/api/prisma.config.ts`, which imports API runtime env helpers through `#api/*`.
 
 The supported Prisma contract is:
 
-- config-to-source imports remain relative
-- Prisma commands do not rely on a TypeScript-only app-local alias mapping
-- the same source files used by runtime env loading stay reachable without adding a Prisma-specific resolution rule
+- `NODE_OPTIONS=--conditions=development`
+- `#api/*` resolves to `./src/*.ts` through package `imports`
+- the same source files used by runtime env loading stay reachable without adding a Prisma-only alias rule
 
 ## Unsupported contract shapes today
 
 The following are intentionally unsupported for `apps/api` today:
 
-- app-local aliases such as `@/`, `~/`, or `src/*`
+- app-local aliases such as `@/`, `~/`, or bare `src/*`
+- a second app-local alias family alongside `#api/*`
 - a Jest-only alias that runtime and Prisma paths do not also share
-- a Nest-only or ts-node-only alias hook that `dist` runtime does not share
-- a Prisma-config-only alias that differs from the main API source contract
+- a Nest-only alias hook that `dist` runtime does not share
+- a Prisma-config-only alias that differs from the main API contract
 
 These are unsupported because they would create multiple resolution contracts for the same workspace instead of one repository-owned contract.
 
@@ -141,19 +149,20 @@ The current contract is not the shortest to read, but it is explicit and reprodu
 Its advantages are:
 
 - one app-local rule works across compile, startup, built runtime, tests, and Prisma config
-- emitted runtime code does not depend on TypeScript-only alias rewrites
+- emitted runtime code uses the same specifiers as the source tree
 - tests do not need a second source-import vocabulary that runtime code lacks
-- the repository avoids tool-specific resolution drift while the API runtime contract is still stabilizing
+- Prisma config does not need a config-only relative import exception
+- the repository avoids tool-specific resolution drift while keeping NodeNext-compatible runtime behavior
 
 ## Future alias prerequisite checklist
 
 Any future proposal to support an app-local alias in `apps/api` must verify all of the following together:
 
 1. TypeScript compile-time resolution accepts the alias without adding deprecated or tool-fragile config.
-2. Nest local startup and watch mode resolve the same alias without a dev-only exception path.
+2. Source startup resolves the same alias without a Nest-only exception path.
 3. The built `dist` runtime resolves the same specifiers without hidden loader assumptions.
 4. Jest resolves the same alias without creating a test-only contract.
 5. Prisma config and Prisma CLI command execution resolve the same alias without a config-only exception path.
 6. Fast local development and parity-oriented runtime validation still exercise the same module-resolution rule.
 
-Until that checklist is satisfied, the supported API contract remains relative-import-first.
+The current `#api/*` contract satisfies that checklist for the API workspace today.

--- a/docs/platform/api-module-resolution-contract.md
+++ b/docs/platform/api-module-resolution-contract.md
@@ -1,0 +1,159 @@
+# API Module Resolution Contract
+
+This document captures the output of issue #158.
+
+Its purpose is to define one repository-owned module resolution contract for `apps/api` across TypeScript compile-time checks, Nest local startup, emitted runtime execution from `dist`, Jest execution, and Prisma command paths.
+
+## Scope
+
+This document defines:
+
+- the currently supported import specifier forms for `apps/api`
+- the current app-local import rule for hand-written API code
+- how the same rule is expected to hold across compile, local startup, `dist` runtime, Jest, and Prisma command execution
+- which specifier forms are intentionally unsupported today
+- what a future API-local alias proposal would need to verify before it becomes supported
+
+This document does not define a repository-wide alias rollout, a package-boundary policy change, or an application runtime migration to pure ESM.
+
+## Contract summary
+
+The current supported module resolution contract for `apps/api` is:
+
+- app-local imports stay relative-import-first
+- workspace package imports use declared package names and exported subpaths only
+- external dependencies use their published package specifiers only
+- no app-local source alias such as `@/`, `~/`, or bare `src/*` is part of the supported API contract today
+
+This contract is intentionally conservative because it is the one contract shape that already aligns with the API workspace's current execution paths without adding separate runtime-specific resolution shims.
+
+## Supported specifier forms
+
+### App-local runtime code under `apps/api/src`
+
+Use relative specifiers for app-local code.
+
+Examples:
+
+- `./health/health.module`
+- `../config/local-runtime-env`
+- `./prisma.service`
+
+Current hand-written API source intentionally uses this pattern in runtime entrypoints, modules, services, and adapters.
+
+### API test files under `apps/api/test`
+
+Use relative specifiers into `../src/*` for API source imports from tests.
+
+Examples:
+
+- `../src/health/health.controller`
+- `../src/logging/api-request-logging.interceptor`
+
+This matches the current `ts-jest` contract and avoids introducing a test-only alias rule that the runtime paths do not also own.
+
+### Workspace package imports
+
+Use declared package names and exported subpaths.
+
+Examples:
+
+- `@focusbuddy/api-contract`
+- `@focusbuddy/logger`
+- `@focusbuddy/config-jest/api`
+
+This follows the repository-wide workspace boundary rules.
+
+### Prisma config imports
+
+Use relative imports from `prisma.config.ts` into API runtime helpers under `./src/*`.
+
+Example:
+
+- `./src/config/local-runtime-env`
+
+This keeps the Prisma CLI path aligned with the API source tree without inventing a separate config-only alias contract.
+
+## Execution-path contract
+
+### TypeScript compile-time resolution
+
+`apps/api/tsconfig.json` extends the shared API baseline with `module` and `moduleResolution` set to `NodeNext`.
+
+The current repository-owned compile-time contract is:
+
+- relative app-local imports inside `src` and `test`
+- declared package imports for workspace packages and external dependencies
+- no repository-owned app-local `paths` mapping for API source aliases
+
+### Nest local startup
+
+The API local dev command uses Nest startup against the hand-written TypeScript source tree.
+
+The supported contract for that path is still the same relative-import-first source layout. No additional alias loader, runtime import hook, or Nest-only resolution override is currently part of the supported API startup contract.
+
+### Emitted runtime execution from `dist`
+
+The parity and built-runtime path executes the emitted output from `dist/main.js`.
+
+The supported contract for that path is:
+
+- TypeScript emits runtime-relative module references that remain valid after the `src` tree is built into `dist`
+- runtime resolution does not depend on TypeScript-only alias metadata surviving into Node execution
+
+This is one reason the current app-local contract stays relative-import-first.
+
+### Jest execution
+
+The API workspace uses `ts-jest` with the local TypeScript config and does not currently opt into a separate API alias contract.
+
+The supported test-resolution contract is:
+
+- tests import source through relative paths into `../src/*`
+- package imports keep using package names
+- Jest does not own a separate app-local alias mapping for API source files today
+
+### Prisma command execution
+
+The Prisma CLI path is configured through `apps/api/prisma.config.ts`, which imports API runtime env helpers from the source tree.
+
+The supported Prisma contract is:
+
+- config-to-source imports remain relative
+- Prisma commands do not rely on a TypeScript-only app-local alias mapping
+- the same source files used by runtime env loading stay reachable without adding a Prisma-specific resolution rule
+
+## Unsupported contract shapes today
+
+The following are intentionally unsupported for `apps/api` today:
+
+- app-local aliases such as `@/`, `~/`, or `src/*`
+- a Jest-only alias that runtime and Prisma paths do not also share
+- a Nest-only or ts-node-only alias hook that `dist` runtime does not share
+- a Prisma-config-only alias that differs from the main API source contract
+
+These are unsupported because they would create multiple resolution contracts for the same workspace instead of one repository-owned contract.
+
+## Why the current contract is acceptable now
+
+The current contract is not the shortest to read, but it is explicit and reproducible.
+
+Its advantages are:
+
+- one app-local rule works across compile, startup, built runtime, tests, and Prisma config
+- emitted runtime code does not depend on TypeScript-only alias rewrites
+- tests do not need a second source-import vocabulary that runtime code lacks
+- the repository avoids tool-specific resolution drift while the API runtime contract is still stabilizing
+
+## Future alias prerequisite checklist
+
+Any future proposal to support an app-local alias in `apps/api` must verify all of the following together:
+
+1. TypeScript compile-time resolution accepts the alias without adding deprecated or tool-fragile config.
+2. Nest local startup and watch mode resolve the same alias without a dev-only exception path.
+3. The built `dist` runtime resolves the same specifiers without hidden loader assumptions.
+4. Jest resolves the same alias without creating a test-only contract.
+5. Prisma config and Prisma CLI command execution resolve the same alias without a config-only exception path.
+6. Fast local development and parity-oriented runtime validation still exercise the same module-resolution rule.
+
+Until that checklist is satisfied, the supported API contract remains relative-import-first.

--- a/docs/platform/import-and-function-style-policy.md
+++ b/docs/platform/import-and-function-style-policy.md
@@ -71,12 +71,13 @@ Current verified app-level exception:
 - `apps/web` should still keep same-folder and nearby relative imports where they remain shorter and clearer, such as CSS modules or tightly local helpers
 - this is a web-local allowance, not a repository-wide default for all workspaces
 
-Current explicit app-level hold:
+Current verified app-level contract:
 
-- `apps/api` should stay relative-import-first for app-local imports under the current NodeNext runtime contract
-- the current API toolchain does not have one repository-owned alias contract that covers TypeScript compile-time resolution, Nest local startup, emitted runtime execution from `dist`, Jest resolution, and Prisma command execution together
-- introducing an API-local alias now would require additional runtime or test-only resolution wiring rather than a documentation-level style preference, which is exactly the drift this policy is meant to avoid
-- revisit API-local aliases only after the repository defines and verifies one explicit alias-resolution story across API build, local dev, parity runtime, Jest, and Prisma commands
+- `apps/api` may use `#api/*` for app-local imports rooted at `apps/api`
+- the current API toolchain now verifies one repository-owned contract across TypeScript compile-time resolution, source startup, emitted runtime execution from `dist`, Jest resolution, and Prisma command execution
+- `#api/*` is the only supported app-local alias family for the API workspace today
+- `@/`, `~/`, and bare `src/*` remain unsupported in `apps/api`
+- same-folder and nearby relative imports remain allowed when they are shorter and clearer than `#api/*`
 
 The current API-side module resolution contract is documented in `docs/platform/api-module-resolution-contract.md`.
 
@@ -139,7 +140,7 @@ This means issue #96 is the decision point, not the implementation vehicle for a
 - current app and package code still uses relative imports in many hand-written files
 - current hand-written exported code is mostly written with function declarations rather than arrow functions
 - the web workspace could pilot an alias earlier than the API workspace, but that would still not justify a repository-wide rule today
-- the API workspace still lacks a verified alias-resolution contract across NodeNext build, Nest startup, Jest, and Prisma command paths
+- the API workspace now has a verified `#api/*` contract across compile, source startup, `dist` runtime, Jest, and Prisma command paths
 - function-style enforcement would be weaker than the repository's existing boundary-oriented rules unless a later issue identifies a concrete maintenance benefit
 
 ## Review triggers

--- a/docs/platform/import-and-function-style-policy.md
+++ b/docs/platform/import-and-function-style-policy.md
@@ -78,6 +78,8 @@ Current explicit app-level hold:
 - introducing an API-local alias now would require additional runtime or test-only resolution wiring rather than a documentation-level style preference, which is exactly the drift this policy is meant to avoid
 - revisit API-local aliases only after the repository defines and verifies one explicit alias-resolution story across API build, local dev, parity runtime, Jest, and Prisma commands
 
+The current API-side module resolution contract is documented in `docs/platform/api-module-resolution-contract.md`.
+
 ## Function declaration style policy
 
 The current repository default for hand-written code is function-declaration-first.

--- a/docs/platform/shared-tooling.md
+++ b/docs/platform/shared-tooling.md
@@ -99,6 +99,8 @@ The repository-wide package ESM migration strategy is documented in `docs/platfo
 
 The current repository policy for app-local import paths and preferred function declaration style is documented in `docs/platform/import-and-function-style-policy.md`.
 
+The current `apps/api` module resolution contract across compile, startup, built runtime, Jest, and Prisma command paths is documented in `docs/platform/api-module-resolution-contract.md`.
+
 The repository default for hand-written JavaScript, TypeScript, and tool config files is now ESM-first. Remaining CommonJS files must be tracked as explicit file-level exceptions in that strategy document.
 
 ## Generated files rule

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2)))(typescript@6.0.2)
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -615,6 +618,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
@@ -2528,6 +2687,11 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -2744,6 +2908,9 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+
+  get-tsconfig@4.13.7:
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
@@ -3962,6 +4129,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
@@ -4401,6 +4571,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   turbo@2.9.4:
     resolution: {integrity: sha512-wZ/kMcZCuK5oEp7sXSSo/5fzKjP9I2EhoiarZjyCm2Ixk0WxFrC/h0gF3686eHHINoFQOOSWgB/pGfvkR8rkgQ==}
@@ -5157,6 +5332,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@hono/node-server@1.19.11(hono@4.12.12)':
@@ -7011,6 +7264,35 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -7263,6 +7545,10 @@ snapshots:
       es-object-atoms: 1.1.1
 
   get-stream@6.0.1: {}
+
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   giget@2.0.0:
     dependencies:
@@ -8642,6 +8928,8 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   restore-cursor@3.1.0:
     dependencies:
       onetime: 5.1.2
@@ -9137,6 +9425,13 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
 
   turbo@2.9.4:
     optionalDependencies:


### PR DESCRIPTION
AIエージェント作成 PR。

## Summary

- implement the repository-owned `#api/*` app-local specifier contract for `apps/api`
- wire the same specifier family through TypeScript, source startup, emitted `dist` runtime, Jest, and Prisma config execution
- convert representative API source files, tests, and Prisma config imports to `#api/*`
- switch API local source startup to `tsx` so the same `#api/*` contract works during TypeScript execution
- update the API module resolution documentation and import policy to describe the implemented contract

## Validation

- `pnpm --filter @focusbuddy/api typecheck`
- `pnpm --filter @focusbuddy/api test`
- `pnpm --filter @focusbuddy/api prisma:generate`
- `pnpm --filter @focusbuddy/api dev`  
  reached Nest startup and failed only at missing local `DATABASE_URL` inputs after resolving `#api/*`
- `pnpm --filter @focusbuddy/api build`
- `node apps/api/dist/main.js`  
  reached Nest startup and failed only at missing local `DATABASE_URL` inputs after resolving `#api/*`

Closes #158
