### PR TITLE
feat(web): /slide-poc に markdown スライド化 PoC を追加

### DIFF
--- a/apps/web/src/app/slide-poc/og/route.tsx
+++ b/apps/web/src/app/slide-poc/og/route.tsx
@@ -5,6 +5,7 @@ import {
   decodeSlideContent,
   extractSlideExcerpt,
   extractSlideTitle,
+  maxSlidePayloadLength,
   splitSlides,
 } from '@/app/slide-poc/slide-content';
 
@@ -17,6 +18,9 @@ export function GET(request: NextRequest) {
   const raw = request.nextUrl.searchParams.get('d');
   if (!raw) {
     return new Response('missing slide content', { status: 400 });
+  }
+  if (raw.length > maxSlidePayloadLength) {
+    return new Response('slide content too large', { status: 400 });
   }
 
   let title = 'Markdown Slide';

--- a/apps/web/src/app/slide-poc/og/route.tsx
+++ b/apps/web/src/app/slide-poc/og/route.tsx
@@ -1,0 +1,89 @@
+import { ImageResponse } from 'next/og';
+import type { NextRequest } from 'next/server';
+
+import {
+  decodeSlideContent,
+  extractSlideExcerpt,
+  extractSlideTitle,
+  splitSlides,
+} from '@/app/slide-poc/slide-content';
+
+export const runtime = 'edge';
+
+const ogImageWidth = 1200;
+const ogImageHeight = 630;
+
+export function GET(request: NextRequest) {
+  const raw = request.nextUrl.searchParams.get('d');
+  if (!raw) {
+    return new Response('missing slide content', { status: 400 });
+  }
+
+  let title = 'Markdown Slide';
+  let excerpt = '';
+  try {
+    const markdown = decodeSlideContent(raw);
+    const slides = splitSlides(markdown);
+    const firstSlide = slides[0];
+    if (firstSlide) {
+      title = extractSlideTitle(firstSlide, title);
+      excerpt = extractSlideExcerpt(firstSlide);
+    }
+  } catch {
+    return new Response('invalid slide content', { status: 400 });
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: '64px 72px',
+          backgroundColor: '#0f172a',
+          color: '#f8fafc',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div
+          style={{
+            fontSize: 24,
+            letterSpacing: 4,
+            color: '#94a3b8',
+            textTransform: 'uppercase',
+            display: 'flex',
+          }}
+        >
+          Markdown Slide PoC
+        </div>
+        <div
+          style={{
+            fontSize: 64,
+            fontWeight: 700,
+            lineHeight: 1.2,
+            display: 'flex',
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            fontSize: 28,
+            color: '#cbd5f5',
+            lineHeight: 1.4,
+            display: 'flex',
+          }}
+        >
+          {excerpt.length > 0 ? excerpt : 'Markdown を貼ってスライドを共有しよう'}
+        </div>
+      </div>
+    ),
+    {
+      width: ogImageWidth,
+      height: ogImageHeight,
+    },
+  );
+}

--- a/apps/web/src/app/slide-poc/page.tsx
+++ b/apps/web/src/app/slide-poc/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+
+import { SlidePocEditor } from '@/app/slide-poc/slide-poc-editor';
+
+export const metadata: Metadata = {
+  title: 'Markdown Slide PoC | FocusBuddy',
+  description: 'Markdown をスライド化し、OGP カードを生成するための実験ページ。',
+};
+
+export default function SlidePocPage() {
+  return <SlidePocEditor />;
+}

--- a/apps/web/src/app/slide-poc/share/page.tsx
+++ b/apps/web/src/app/slide-poc/share/page.tsx
@@ -1,0 +1,127 @@
+import type { Metadata } from 'next';
+import { headers } from 'next/headers';
+import Link from 'next/link';
+
+import {
+  decodeSlideContent,
+  extractSlideExcerpt,
+  extractSlideTitle,
+  splitSlides,
+} from '@/app/slide-poc/slide-content';
+import styles from '@/app/slide-poc/styles.module.css';
+
+type SharePageProps = {
+  searchParams: Promise<{ d?: string | string[] }>;
+};
+
+type SlideShareSummary = {
+  slides: string[];
+  firstTitle: string;
+  firstExcerpt: string;
+  encoded: string;
+};
+
+export async function generateMetadata({ searchParams }: SharePageProps): Promise<Metadata> {
+  const summary = await readSharedSlides(searchParams);
+  if (!summary) {
+    return {
+      title: 'Markdown Slide PoC',
+      description: '共有 URL のスライド内容を表示します。',
+    };
+  }
+
+  const baseUrl = await resolveBaseUrl();
+  const ogImageUrl = `${baseUrl}/slide-poc/og?d=${summary.encoded}`;
+  const description =
+    summary.firstExcerpt.length > 0 ? summary.firstExcerpt : 'Markdown から生成されたスライド';
+
+  return {
+    title: `${summary.firstTitle} | Markdown Slide PoC`,
+    description,
+    openGraph: {
+      title: summary.firstTitle,
+      description,
+      type: 'article',
+      images: [{ url: ogImageUrl, width: 1200, height: 630 }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: summary.firstTitle,
+      description,
+      images: [ogImageUrl],
+    },
+  };
+}
+
+export default async function SlideSharePage({ searchParams }: SharePageProps) {
+  const summary = await readSharedSlides(searchParams);
+
+  if (!summary) {
+    return (
+      <div className={styles.layout}>
+        <h1 className={styles.heading}>共有 URL を読み込めませんでした</h1>
+        <p className={styles.subheading}>
+          URL に <code>d</code> パラメータが含まれていないか、デコードに失敗しました。
+        </p>
+        <Link className={styles.secondaryButton} href="/slide-poc">
+          エディタへ戻る
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.layout}>
+      <div>
+        <h1 className={styles.heading}>{summary.firstTitle}</h1>
+        <p className={styles.subheading}>共有された Markdown スライド ({summary.slides.length} 枚)</p>
+      </div>
+      <div className={styles.previewPane}>
+        {summary.slides.map((slide, index) => (
+          <article className={styles.slide} key={`shared-slide-${index.toString()}`}>
+            <div className={styles.slideIndex}>
+              Slide {index + 1} / {summary.slides.length}
+            </div>
+            <div className={styles.slideBody}>{slide}</div>
+          </article>
+        ))}
+      </div>
+      <Link className={styles.secondaryButton} href="/slide-poc">
+        エディタへ戻る
+      </Link>
+    </div>
+  );
+}
+
+async function readSharedSlides(
+  searchParamsPromise: SharePageProps['searchParams'],
+): Promise<SlideShareSummary | undefined> {
+  const params = await searchParamsPromise;
+  const raw = Array.isArray(params.d) ? params.d[0] : params.d;
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    const markdown = decodeSlideContent(raw);
+    const slides = splitSlides(markdown);
+    const firstSlide = slides[0];
+    if (!firstSlide) {
+      return undefined;
+    }
+    return {
+      slides,
+      firstTitle: extractSlideTitle(firstSlide, 'Markdown Slide'),
+      firstExcerpt: extractSlideExcerpt(firstSlide),
+      encoded: raw,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveBaseUrl(): Promise<string> {
+  const headerList = await headers();
+  const host = headerList.get('host') ?? 'localhost:3000';
+  const protocol = headerList.get('x-forwarded-proto') ?? (host.startsWith('localhost') ? 'http' : 'https');
+  return `${protocol}://${host}`;
+}

--- a/apps/web/src/app/slide-poc/share/page.tsx
+++ b/apps/web/src/app/slide-poc/share/page.tsx
@@ -6,6 +6,7 @@ import {
   decodeSlideContent,
   extractSlideExcerpt,
   extractSlideTitle,
+  maxSlidePayloadLength,
   splitSlides,
 } from '@/app/slide-poc/slide-content';
 import styles from '@/app/slide-poc/styles.module.css';
@@ -99,6 +100,9 @@ async function readSharedSlides(
   const params = await searchParamsPromise;
   const raw = Array.isArray(params.d) ? params.d[0] : params.d;
   if (!raw) {
+    return undefined;
+  }
+  if (raw.length > maxSlidePayloadLength) {
     return undefined;
   }
   try {

--- a/apps/web/src/app/slide-poc/slide-content.ts
+++ b/apps/web/src/app/slide-poc/slide-content.ts
@@ -1,0 +1,56 @@
+const slideSeparator = /^---\s*$/m;
+
+export function splitSlides(markdown: string): string[] {
+  const slides = markdown
+    .split(slideSeparator)
+    .map((slide) => slide.trim())
+    .filter((slide) => slide.length > 0);
+  return slides.length > 0 ? slides : [markdown.trim()].filter((slide) => slide.length > 0);
+}
+
+export function extractSlideTitle(slideMarkdown: string, fallback: string): string {
+  const headingMatch = slideMarkdown.match(/^#{1,6}\s+(.+?)\s*$/m);
+  const headingText = headingMatch?.[1]?.trim();
+  if (headingText && headingText.length > 0) {
+    return headingText;
+  }
+  const firstLine = slideMarkdown.split('\n').find((line) => line.trim().length > 0);
+  return firstLine?.trim() ?? fallback;
+}
+
+export function extractSlideExcerpt(slideMarkdown: string, max = 140): string {
+  const lines = slideMarkdown.split('\n');
+  const headingIndex = lines.findIndex((line) => /^#{1,6}\s+/.test(line.trim()));
+  const body = (headingIndex >= 0 ? lines.slice(headingIndex + 1) : lines)
+    .map((line) => line.trim().replace(/^[-*]\s+/, '').replace(/[`*_>#~]/g, ''))
+    .filter((line) => line.length > 0)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (body.length <= max) {
+    return body;
+  }
+  return `${body.slice(0, max - 1)}…`;
+}
+
+export function encodeSlideContent(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  const base64 = btoa(binary);
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function decodeSlideContent(encoded: string): string {
+  const base64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+  const paddingNeeded = (4 - (base64.length % 4)) % 4;
+  const padded = base64 + '='.repeat(paddingNeeded);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return new TextDecoder().decode(bytes);
+}

--- a/apps/web/src/app/slide-poc/slide-content.ts
+++ b/apps/web/src/app/slide-poc/slide-content.ts
@@ -1,5 +1,7 @@
 const slideSeparator = /^---\s*$/m;
 
+export const maxSlidePayloadLength = 16384;
+
 export function splitSlides(markdown: string): string[] {
   const slides = markdown
     .split(slideSeparator)
@@ -9,7 +11,7 @@ export function splitSlides(markdown: string): string[] {
 }
 
 export function extractSlideTitle(slideMarkdown: string, fallback: string): string {
-  const headingMatch = slideMarkdown.match(/^#{1,6}[ \t]+(.+)$/m);
+  const headingMatch = slideMarkdown.match(/^#{1,6}[ \t]+(\S.*)$/m);
   const headingText = headingMatch?.[1]?.trim();
   if (headingText && headingText.length > 0) {
     return headingText;

--- a/apps/web/src/app/slide-poc/slide-content.ts
+++ b/apps/web/src/app/slide-poc/slide-content.ts
@@ -9,7 +9,7 @@ export function splitSlides(markdown: string): string[] {
 }
 
 export function extractSlideTitle(slideMarkdown: string, fallback: string): string {
-  const headingMatch = slideMarkdown.match(/^#{1,6}\s+(.+?)\s*$/m);
+  const headingMatch = slideMarkdown.match(/^#{1,6}[ \t]+(.+)$/m);
   const headingText = headingMatch?.[1]?.trim();
   if (headingText && headingText.length > 0) {
     return headingText;

--- a/apps/web/src/app/slide-poc/slide-poc-editor.tsx
+++ b/apps/web/src/app/slide-poc/slide-poc-editor.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import {
+  encodeSlideContent,
+  extractSlideTitle,
+  splitSlides,
+} from '@/app/slide-poc/slide-content';
+import styles from '@/app/slide-poc/styles.module.css';
+
+const initialMarkdown = `# Markdown Slide PoC
+
+このエディタに Markdown を書いて「スライド化」を押すとスライド表示になります。
+
+---
+
+## スライドを増やすには
+
+\`---\` で区切るだけ。
+
+- 箇条書きも書けます
+- 見出しはタイトルになります
+
+---
+
+## 共有 URL を生成
+
+「共有 URL を生成」を押すと OGP カード化用 URL がコピーされます。
+`;
+
+type ShareLink = {
+  url: string;
+  ogImageUrl: string;
+};
+
+export function SlidePocEditor() {
+  const [markdown, setMarkdown] = useState(initialMarkdown);
+  const [slides, setSlides] = useState<string[] | undefined>(undefined);
+  const [shareLink, setShareLink] = useState<ShareLink | undefined>(undefined);
+  const [statusMessage, setStatusMessage] = useState('Markdown を編集して「スライド化」を押してください。');
+
+  const handleSlidify = () => {
+    const nextSlides = splitSlides(markdown);
+    setSlides(nextSlides);
+    setShareLink(undefined);
+    setStatusMessage(
+      nextSlides.length > 0
+        ? `${nextSlides.length} 枚のスライドを生成しました。`
+        : 'スライドにできる内容がありません。',
+    );
+  };
+
+  const handleGenerateShareLink = async () => {
+    if (!slides || slides.length === 0) {
+      setStatusMessage('まず「スライド化」を押してください。');
+      return;
+    }
+    const encoded = encodeSlideContent(markdown);
+    const origin = window.location.origin;
+    const shareUrl = `${origin}/slide-poc/share?d=${encoded}`;
+    const ogImageUrl = `${origin}/slide-poc/og?d=${encoded}`;
+    setShareLink({ url: shareUrl, ogImageUrl });
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(shareUrl);
+        setStatusMessage('共有 URL をクリップボードにコピーしました。');
+        return;
+      } catch {
+        // fall through to manual copy guidance
+      }
+    }
+    setStatusMessage('共有 URL を生成しました。下のボックスから手動でコピーしてください。');
+  };
+
+  return (
+    <div className={styles.layout}>
+      <div>
+        <h1 className={styles.heading}>Markdown Slide PoC</h1>
+        <p className={styles.subheading}>
+          Markdown をスライド化し、SNS 用 OGP カードを試すための実験ページです。
+        </p>
+      </div>
+      <div className={styles.workspace}>
+        <div className={styles.editorPane}>
+          <textarea
+            aria-label="Markdown editor"
+            className={styles.editor}
+            onChange={(event) => setMarkdown(event.target.value)}
+            spellCheck={false}
+            value={markdown}
+          />
+          <div className={styles.actionRow}>
+            <button className={styles.primaryButton} onClick={handleSlidify} type="button">
+              スライド化
+            </button>
+            <button
+              className={styles.secondaryButton}
+              disabled={!slides || slides.length === 0}
+              onClick={handleGenerateShareLink}
+              type="button"
+            >
+              共有 URL を生成
+            </button>
+          </div>
+          <p aria-live="polite" className={styles.statusLine}>
+            {statusMessage}
+          </p>
+          {shareLink ? (
+            <div>
+              <input
+                aria-label="共有 URL"
+                className={styles.shareUrl}
+                onFocus={(event) => event.currentTarget.select()}
+                readOnly
+                value={shareLink.url}
+              />
+              <p className={styles.statusLine}>
+                OGP 画像プレビュー:{' '}
+                <a href={shareLink.ogImageUrl} rel="noreferrer" target="_blank">
+                  {shareLink.ogImageUrl}
+                </a>
+              </p>
+            </div>
+          ) : undefined}
+        </div>
+        <div className={styles.previewPane}>
+          {slides && slides.length > 0 ? (
+            slides.map((slide, index) => (
+              <SlideCard
+                index={index + 1}
+                key={`slide-${index.toString()}-${slide.slice(0, 16)}`}
+                markdown={slide}
+                total={slides.length}
+              />
+            ))
+          ) : (
+            <div className={styles.previewEmpty}>「スライド化」を押すとプレビューが表示されます。</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type SlideCardProps = {
+  index: number;
+  markdown: string;
+  total: number;
+};
+
+function SlideCard({ index, markdown, total }: SlideCardProps) {
+  const { title, body } = useMemo(() => splitTitleAndBody(markdown), [markdown]);
+  return (
+    <article className={styles.slide}>
+      <div className={styles.slideIndex}>
+        Slide {index} / {total}
+      </div>
+      {title ? <h2 className={styles.slideHeading}>{title}</h2> : undefined}
+      <div className={styles.slideBody}>{body}</div>
+    </article>
+  );
+}
+
+function splitTitleAndBody(markdown: string): { title: string | undefined; body: string } {
+  const trimmed = markdown.trim();
+  const lines = trimmed.split('\n');
+  const headingIndex = lines.findIndex((line) => /^#{1,6}\s+/.test(line.trim()));
+  if (headingIndex === -1) {
+    return { title: undefined, body: trimmed };
+  }
+  const title = extractSlideTitle(trimmed, '');
+  const body = lines.slice(headingIndex + 1).join('\n').trim();
+  return { title: title.length > 0 ? title : undefined, body };
+}

--- a/apps/web/src/app/slide-poc/styles.module.css
+++ b/apps/web/src/app/slide-poc/styles.module.css
@@ -1,0 +1,154 @@
+.layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: #1f2937;
+}
+
+.heading {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.subheading {
+  font-size: 0.95rem;
+  color: #4b5563;
+  margin: 0;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+  align-items: stretch;
+}
+
+@media (width <= 900px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+}
+
+.editorPane {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.editor {
+  width: 100%;
+  min-height: 360px;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  padding: 0.875rem 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  resize: vertical;
+}
+
+.actionRow {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.primaryButton,
+.secondaryButton {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.55rem 1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.primaryButton {
+  background-color: #2563eb;
+  color: #fff;
+}
+
+.primaryButton:hover {
+  background-color: #1d4ed8;
+}
+
+.secondaryButton {
+  background-color: #fff;
+  color: #1f2937;
+  border-color: #d1d5db;
+}
+
+.secondaryButton:hover {
+  background-color: #f3f4f6;
+}
+
+.statusLine {
+  font-size: 0.85rem;
+  color: #4b5563;
+  min-height: 1.25rem;
+}
+
+.shareUrl {
+  width: 100%;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.85rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background-color: #f9fafb;
+  word-break: break-all;
+}
+
+.previewPane {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 360px;
+}
+
+.previewEmpty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed #d1d5db;
+  border-radius: 8px;
+  color: #9ca3af;
+  padding: 2rem;
+  height: 100%;
+}
+
+.slide {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 1.25rem 1.5rem;
+  background-color: #fff;
+  box-shadow: 0 1px 2px rgb(15 23 42 / 4%);
+}
+
+.slideIndex {
+  font-size: 0.75rem;
+  color: #6b7280;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.slideBody {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  margin-top: 0.5rem;
+}
+
+.slideHeading {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin: 0 0 0.75rem;
+}

--- a/apps/web/test/slide-poc-content.test.ts
+++ b/apps/web/test/slide-poc-content.test.ts
@@ -1,0 +1,74 @@
+/** @jest-environment node */
+
+import {
+  decodeSlideContent,
+  encodeSlideContent,
+  extractSlideExcerpt,
+  extractSlideTitle,
+  splitSlides,
+} from '@/app/slide-poc/slide-content';
+
+describe('slide-content utilities', () => {
+  describe('splitSlides', () => {
+    it('splits markdown on horizontal rules', () => {
+      const markdown = '# A\n\nfirst\n\n---\n\n# B\n\nsecond';
+      expect(splitSlides(markdown)).toEqual(['# A\n\nfirst', '# B\n\nsecond']);
+    });
+
+    it('returns the entire markdown as a single slide when no separator exists', () => {
+      const markdown = '# only one\n\nbody';
+      expect(splitSlides(markdown)).toEqual(['# only one\n\nbody']);
+    });
+
+    it('drops empty slide segments', () => {
+      const markdown = '\n---\n\n# A\n\n---\n\n';
+      expect(splitSlides(markdown)).toEqual(['# A']);
+    });
+  });
+
+  describe('extractSlideTitle', () => {
+    it('returns the heading text', () => {
+      expect(extractSlideTitle('# Hello world\n\nbody', 'fallback')).toBe('Hello world');
+    });
+
+    it('falls back to first non-empty line when no heading exists', () => {
+      expect(extractSlideTitle('intro line\nnext line', 'fallback')).toBe('intro line');
+    });
+
+    it('falls back to the supplied default for empty content', () => {
+      expect(extractSlideTitle('   ', 'fallback')).toBe('fallback');
+    });
+  });
+
+  describe('extractSlideExcerpt', () => {
+    it('joins body lines with spaces and strips markdown markers', () => {
+      const slide = '# Title\n\n- **bold** point\n- second point';
+      expect(extractSlideExcerpt(slide)).toBe('bold point second point');
+    });
+
+    it('truncates long excerpts with an ellipsis', () => {
+      const longBody = 'abcdefghij '.repeat(40).trim();
+      const slide = `# Title\n\n${longBody}`;
+      const excerpt = extractSlideExcerpt(slide, 30);
+      expect(excerpt.length).toBe(30);
+      expect(excerpt.endsWith('…')).toBe(true);
+    });
+  });
+
+  describe('encodeSlideContent / decodeSlideContent', () => {
+    it('roundtrips ASCII content', () => {
+      const text = '# Hello\n\n- one\n- two\n\n---\n\n# Bye';
+      const encoded = encodeSlideContent(text);
+      expect(encoded).not.toContain('+');
+      expect(encoded).not.toContain('/');
+      expect(encoded).not.toContain('=');
+      expect(decodeSlideContent(encoded)).toBe(text);
+    });
+
+    it('roundtrips multibyte content', () => {
+      const text = '# 日本語タイトル\n\n本文に絵文字 🎌 と中黒・も含む';
+      const encoded = encodeSlideContent(text);
+      expect(decodeSlideContent(encoded)).toBe(text);
+    });
+  });
+});

--- a/apps/web/test/slide-poc-og-route.test.ts
+++ b/apps/web/test/slide-poc-og-route.test.ts
@@ -53,4 +53,12 @@ describe('slide-poc og route', () => {
     const response = GET(buildRequest('?d=%25%25%25not-valid%25%25%25') as never);
     expect(response.status).toBe(400);
   });
+
+  it('returns 400 when the d parameter exceeds the size cap', async () => {
+    const { GET } = await import('@/app/slide-poc/og/route');
+    const { maxSlidePayloadLength } = await import('@/app/slide-poc/slide-content');
+    const oversized = 'a'.repeat(maxSlidePayloadLength + 1);
+    const response = GET(buildRequest(`?d=${oversized}`) as never);
+    expect(response.status).toBe(400);
+  });
 });

--- a/apps/web/test/slide-poc-og-route.test.ts
+++ b/apps/web/test/slide-poc-og-route.test.ts
@@ -1,0 +1,56 @@
+/** @jest-environment node */
+
+import { jest } from '@jest/globals';
+
+type ImageResponseInit = { width?: number; height?: number };
+
+function mockImageResponse(_element: unknown, init?: ImageResponseInit): Response {
+  return new Response('mock-png-bytes', {
+    headers: {
+      'content-type': 'image/png',
+      'x-image-width': String(init?.width ?? 0),
+      'x-image-height': String(init?.height ?? 0),
+    },
+  });
+}
+
+jest.unstable_mockModule('next/og', () => ({
+  ImageResponse: mockImageResponse,
+}));
+
+type RouteRequestShape = {
+  nextUrl: URL;
+};
+
+function buildRequest(query: string): RouteRequestShape {
+  return {
+    nextUrl: new URL(`https://example.com/slide-poc/og${query}`),
+  };
+}
+
+describe('slide-poc og route', () => {
+  it('returns a 1200x630 PNG response for valid encoded markdown', async () => {
+    const { GET } = await import('@/app/slide-poc/og/route');
+    const { encodeSlideContent } = await import('@/app/slide-poc/slide-content');
+
+    const encoded = encodeSlideContent('# OGP タイトル\n\n本文サンプル');
+    const response = GET(buildRequest(`?d=${encoded}`) as never);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('image/png');
+    expect(response.headers.get('x-image-width')).toBe('1200');
+    expect(response.headers.get('x-image-height')).toBe('630');
+  });
+
+  it('returns 400 when the d parameter is missing', async () => {
+    const { GET } = await import('@/app/slide-poc/og/route');
+    const response = GET(buildRequest('') as never);
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 when the encoded content cannot be decoded', async () => {
+    const { GET } = await import('@/app/slide-poc/og/route');
+    const response = GET(buildRequest('?d=%25%25%25not-valid%25%25%25') as never);
+    expect(response.status).toBe(400);
+  });
+});

--- a/apps/web/test/slide-poc-share-metadata.test.ts
+++ b/apps/web/test/slide-poc-share-metadata.test.ts
@@ -1,0 +1,77 @@
+/** @jest-environment node */
+
+import { jest } from '@jest/globals';
+
+const headersMock: jest.Mock<() => Promise<Headers>> = jest.fn();
+
+jest.unstable_mockModule('next/headers', () => ({
+  headers: headersMock,
+}));
+
+describe('slide-poc share page metadata', () => {
+  beforeEach(() => {
+    headersMock.mockReset();
+    headersMock.mockResolvedValue(
+      new Headers({
+        host: 'example.com',
+        'x-forwarded-proto': 'https',
+      }),
+    );
+  });
+
+  it('emits OGP and Twitter card metadata pointing to the og route', async () => {
+    const { generateMetadata } = await import('@/app/slide-poc/share/page');
+    const { encodeSlideContent } = await import('@/app/slide-poc/slide-content');
+
+    const markdown = '# 共有タイトル\n\n本文の概要を OGP の description に乗せたい。';
+    const encoded = encodeSlideContent(markdown);
+
+    const metadata = await generateMetadata({
+      searchParams: Promise.resolve({ d: encoded }),
+    });
+
+    expect(metadata.title).toBe('共有タイトル | Markdown Slide PoC');
+    expect(metadata.description).toBe('本文の概要を OGP の description に乗せたい。');
+
+    expect(metadata.openGraph).toMatchObject({
+      title: '共有タイトル',
+      type: 'article',
+      images: [
+        {
+          url: `https://example.com/slide-poc/og?d=${encoded}`,
+          width: 1200,
+          height: 630,
+        },
+      ],
+    });
+
+    expect(metadata.twitter).toMatchObject({
+      card: 'summary_large_image',
+      title: '共有タイトル',
+      images: [`https://example.com/slide-poc/og?d=${encoded}`],
+    });
+  });
+
+  it('returns a fallback metadata object when the d parameter is missing', async () => {
+    const { generateMetadata } = await import('@/app/slide-poc/share/page');
+
+    const metadata = await generateMetadata({
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(metadata.title).toBe('Markdown Slide PoC');
+    expect(metadata.openGraph).toBeUndefined();
+    expect(metadata.twitter).toBeUndefined();
+  });
+
+  it('returns a fallback metadata object for invalid encoded content', async () => {
+    const { generateMetadata } = await import('@/app/slide-poc/share/page');
+
+    const metadata = await generateMetadata({
+      searchParams: Promise.resolve({ d: '!!!not-base64!!!' }),
+    });
+
+    expect(metadata.title).toBe('Markdown Slide PoC');
+    expect(metadata.openGraph).toBeUndefined();
+  });
+});

--- a/apps/web/test/slide-poc-share-metadata.test.ts
+++ b/apps/web/test/slide-poc-share-metadata.test.ts
@@ -74,4 +74,17 @@ describe('slide-poc share page metadata', () => {
     expect(metadata.title).toBe('Markdown Slide PoC');
     expect(metadata.openGraph).toBeUndefined();
   });
+
+  it('returns a fallback metadata object when the d parameter exceeds the size cap', async () => {
+    const { generateMetadata } = await import('@/app/slide-poc/share/page');
+    const { maxSlidePayloadLength } = await import('@/app/slide-poc/slide-content');
+    const oversized = 'a'.repeat(maxSlidePayloadLength + 1);
+
+    const metadata = await generateMetadata({
+      searchParams: Promise.resolve({ d: oversized }),
+    });
+
+    expect(metadata.title).toBe('Markdown Slide PoC');
+    expect(metadata.openGraph).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Closes #188

## Summary

- `apps/web/src/app/slide-poc/` 配下に markdown→スライド変換 PoC を追加
- 共有 URL は payload を URL に encode する方式(永続化なし)
- OG 画像は `/slide-poc/og?d=...` で動的生成
- ユニットテスト 3 本: slide-content / og route / share metadata

## Test plan

- [ ] `pnpm --filter @focusbuddy/web test` が通る
- [ ] devcontainer から `pnpm dev` で web を起動し、`/slide-poc` で markdown を入力するとスライド化される
- [ ] 共有 URL `/slide-poc/share?d=...` を開くとスライド本文が表示される
- [ ] OG 画像 URL `/slide-poc/og?d=...` を直接開くと PNG が返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)