### PR TITLE
chore(infra): devcontainer/local-dev を共有ネットワーク + concurrently 構成に整理

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,15 @@
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "runArgs": ["--name", "${localWorkspaceFolderBasename}-dev", "--env-file", ".devcontainer/.devcontainer.env"],
+  "runArgs": [
+    "--name",
+    "${localWorkspaceFolderBasename}-dev",
+    "--network",
+    "focusbuddy-net",
+    "--env-file",
+    ".devcontainer/.devcontainer.env"
+  ],
+  "forwardPorts": [3000, 3001],
   "initializeCommand": "bash .devcontainer/initialize.sh",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/focusbuddy,type=bind,consistency=cached",
   "workspaceFolder": "/workspaces/focusbuddy",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,12 @@
   "containerEnv": {
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
     "GIT_PAGER": "cat",
-    "FOCUSBUDDY_WORKSPACE_MOUNT": "${localWorkspaceFolder}"
+    "FOCUSBUDDY_WORKSPACE_MOUNT": "${localWorkspaceFolder}",
+    // The base image (node:24-bookworm) only ships C / C.utf8 / POSIX locales.
+    // Without this, glibc falls back to POSIX → wcwidth() reports CJK chars as
+    // width 1, which breaks Claude Code's TUI redraw on `claude --resume`.
+    "LANG": "C.UTF-8",
+    "LC_ALL": "C.UTF-8"
   },
   "remoteEnv": {
     "http_proxy": "http://127.0.0.1:8888",

--- a/.devcontainer/initialize.sh
+++ b/.devcontainer/initialize.sh
@@ -73,3 +73,16 @@ upsert_env "HOST_GIT_USER_EMAIL" "$HOST_EMAIL" "$ENV_FILE"
 if [ -z "$HOST_NAME" ] || [ -z "$HOST_EMAIL" ]; then
     echo "[initialize] NOTE: host git user.name or user.email is unset. Container commits may require manual config." >&2
 fi
+
+# 6. Ensure the shared docker network exists before the devcontainer joins it.
+# The compose stack (postgres, auth) attaches as `external: true`, and the
+# devcontainer joins via runArgs --network. Created idempotently on the host.
+NETWORK_NAME="focusbuddy-net"
+if command -v docker >/dev/null 2>&1; then
+    if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
+        docker network create "$NETWORK_NAME" >/dev/null
+        echo "[initialize] Created docker network: $NETWORK_NAME"
+    fi
+else
+    echo "[initialize] WARNING: docker not found on host. devcontainer requires docker." >&2
+fi

--- a/.devcontainer/initialize.sh
+++ b/.devcontainer/initialize.sh
@@ -5,13 +5,17 @@ set -euo pipefail
 # Runs on the VS Code host before the container starts.
 #
 # Responsibilities:
-# 1. Ensure .devcontainer/.devcontainer.env exists (inherits previous touch behavior).
-# 2. Read host's git user.name / user.email (from global git config).
-# 3. Upsert HOST_GIT_USER_NAME / HOST_GIT_USER_EMAIL into .devcontainer.env,
-#    preserving other lines (e.g. GH_TOKEN). Empty values remove the line.
-# 4. Never touch host's ~/.gitconfig (read-only wrt host).
+# 1. Ensure .devcontainer/.devcontainer.env exists.
+# 2. If git is available on the host, sync host's git user.name / user.email
+#    into HOST_GIT_USER_NAME / HOST_GIT_USER_EMAIL in .devcontainer.env
+#    (preserving other lines such as GH_TOKEN). Empty values remove the line.
+#    This step is skipped — not fatal — when git is missing, so that the
+#    docker network setup below still runs.
+# 3. Ensure the shared docker network `focusbuddy-net` exists, so the
+#    devcontainer can join it via runArgs --network and resolve compose
+#    service names (postgres, auth) by hostname.
 #
-# Atomicity: write via mktemp (same directory) + mv → rename within same FS.
+# Atomicity: env-file writes go through mktemp + mv → rename within same FS.
 # trap EXIT cleans up the temp file on error/interrupt.
 # Line match is anchored to start-of-line (^KEY=) to avoid substring collisions.
 
@@ -23,27 +27,7 @@ if [ ! -f "$ENV_FILE" ]; then
     touch "$ENV_FILE"
 fi
 
-# 2. git availability check
-if ! command -v git >/dev/null 2>&1; then
-    echo "[initialize] WARNING: git not found on host. Skipping git user sync." >&2
-    exit 0
-fi
-
-# 3. Read host values (unset -> empty string)
-HOST_NAME="$(git config --global user.name || true)"
-HOST_EMAIL="$(git config --global user.email || true)"
-
-# 4. Reject values containing newlines (would corrupt env-file format).
-if [[ "$HOST_NAME" == *$'\n'* ]]; then
-    echo "[initialize] WARNING: host git user.name contains newline; skipping." >&2
-    HOST_NAME=""
-fi
-if [[ "$HOST_EMAIL" == *$'\n'* ]]; then
-    echo "[initialize] WARNING: host git user.email contains newline; skipping." >&2
-    HOST_EMAIL=""
-fi
-
-# 5. upsert helper.
+# upsert helper.
 # If value is non-empty: replace existing ^KEY= line, or append if absent.
 # If value is empty: remove any existing ^KEY= line (no-op if absent).
 upsert_env() {
@@ -67,14 +51,32 @@ upsert_env() {
     trap - EXIT
 }
 
-upsert_env "HOST_GIT_USER_NAME" "$HOST_NAME" "$ENV_FILE"
-upsert_env "HOST_GIT_USER_EMAIL" "$HOST_EMAIL" "$ENV_FILE"
+# 2. git user sync (skipped — not fatal — if git is unavailable on host).
+if command -v git >/dev/null 2>&1; then
+    HOST_NAME="$(git config --global user.name || true)"
+    HOST_EMAIL="$(git config --global user.email || true)"
 
-if [ -z "$HOST_NAME" ] || [ -z "$HOST_EMAIL" ]; then
-    echo "[initialize] NOTE: host git user.name or user.email is unset. Container commits may require manual config." >&2
+    # Reject values containing newlines (would corrupt env-file format).
+    if [[ "$HOST_NAME" == *$'\n'* ]]; then
+        echo "[initialize] WARNING: host git user.name contains newline; skipping." >&2
+        HOST_NAME=""
+    fi
+    if [[ "$HOST_EMAIL" == *$'\n'* ]]; then
+        echo "[initialize] WARNING: host git user.email contains newline; skipping." >&2
+        HOST_EMAIL=""
+    fi
+
+    upsert_env "HOST_GIT_USER_NAME" "$HOST_NAME" "$ENV_FILE"
+    upsert_env "HOST_GIT_USER_EMAIL" "$HOST_EMAIL" "$ENV_FILE"
+
+    if [ -z "$HOST_NAME" ] || [ -z "$HOST_EMAIL" ]; then
+        echo "[initialize] NOTE: host git user.name or user.email is unset. Container commits may require manual config." >&2
+    fi
+else
+    echo "[initialize] WARNING: git not found on host. Skipping git user sync." >&2
 fi
 
-# 6. Ensure the shared docker network exists before the devcontainer joins it.
+# 3. Ensure the shared docker network exists before the devcontainer joins it.
 # The compose stack (postgres, auth) attaches as `external: true`, and the
 # devcontainer joins via runArgs --network. Created idempotently on the host.
 NETWORK_NAME="focusbuddy-net"

--- a/.env.example
+++ b/.env.example
@@ -26,9 +26,5 @@ FOCUSBUDDY_AUTH_BASE_URL=http://auth:9099
 
 # web のクライアントから ad-hoc api を叩く必要が出たら以下も指定:
 # NEXT_PUBLIC_FOCUSBUDDY_API_BASE_URL=http://localhost:3001
-
-  # getent hosts postgres   # → IP が返るはず
-  # getent hosts auth       # → IP が返るはず
-  # nc -zv postgres 5432    # → succeeded
-  # nc -zv auth 9099        # → succeeded
-  # 5. ad-hoc 起動
+#
+# 起動後に接続性をスモーク確認するには `bash scripts/local-dev/verify.sh`。

--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,6 @@ POSTGRES_USER=focusbuddy
 POSTGRES_PASSWORD=focusbuddy
 POSTGRES_PORT=5432
 
-API_PORT=3001
-WEB_PORT=3000
 AUTH_PORT=9099
 
 FOCUSBUDDY_AUTH_MODE=stub
@@ -14,3 +12,23 @@ FOCUSBUDDY_AUTH_MODE=stub
 # Optional override for bind mounts when docker compose is run against a host daemon
 # from inside another containerized environment.
 # FOCUSBUDDY_WORKSPACE_MOUNT=/absolute/path/to/focusbuddy
+
+# --- Ad-hoc dev (web/api をホスト直起動する場合) -----------------------------
+# `just dev` で起動する compose は postgres と auth のみ。web / api は
+# 開発コンテナ内から `pnpm --filter @focusbuddy/web dev` /
+# `pnpm --filter @focusbuddy/api dev` で直接起動する想定。
+#
+# devcontainer は `focusbuddy-net` 共有ネットワークに join する設定なので、
+# サービス名 `postgres` / `auth` で compose 側のコンテナへ Docker DNS 解決
+# できる。下の値はそのまま .env にコピーで動作する:
+DATABASE_URL=postgres://focusbuddy:focusbuddy@postgres:5432/focusbuddy
+FOCUSBUDDY_AUTH_BASE_URL=http://auth:9099
+
+# web のクライアントから ad-hoc api を叩く必要が出たら以下も指定:
+# NEXT_PUBLIC_FOCUSBUDDY_API_BASE_URL=http://localhost:3001
+
+  # getent hosts postgres   # → IP が返るはず
+  # getent hosts auth       # → IP が返るはず
+  # nc -zv postgres 5432    # → succeeded
+  # nc -zv auth 9099        # → succeeded
+  # 5. ad-hoc 起動

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "build": "pnpm contract:build && pnpm logger:build && pnpm prisma:generate && pnpm --dir ../.. exec tsc --project apps/api/tsconfig.build.json",
     "contract:build": "pnpm --dir ../.. --filter @focusbuddy/api-contract build",
     "dev": "pnpm contract:build && pnpm logger:build && pnpm prisma:generate && NODE_OPTIONS=--conditions=development pnpm exec tsx watch src/main.ts",
+    "dev:run": "NODE_OPTIONS=--conditions=development pnpm exec tsx watch src/main.ts",
     "logger:build": "pnpm --dir ../.. --filter @focusbuddy/logger build",
     "lint": "pnpm --dir ../.. exec oxlint apps/api/src apps/api/test apps/api/prisma",
     "measure:baseline": "pnpm exec tsx ./scripts/measure-api-baseline/index.ts",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "pnpm contract:build && pnpm logger:build && next build",
     "contract:build": "pnpm --dir ../.. --filter @focusbuddy/api-contract build",
-    "dev": "pnpm contract:build && pnpm logger:build && next dev --hostname 0.0.0.0 --port 3000",
+    "dev": "pnpm contract:build && pnpm logger:build && next dev --port 3000",
     "dev:run": "next dev --hostname 0.0.0.0 --port 3000",
     "logger:build": "pnpm --dir ../.. --filter @focusbuddy/logger build",
     "lint": "pnpm lint:styles && pnpm --dir ../.. exec oxlint apps/web/src apps/web/test && pnpm --dir ../.. lint:boundaries",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "pnpm contract:build && pnpm logger:build && next build",
     "contract:build": "pnpm --dir ../.. --filter @focusbuddy/api-contract build",
-    "dev": "pnpm contract:build && pnpm logger:build && next dev",
-    "dev:compose": "pnpm contract:build && pnpm logger:build && next dev --hostname 0.0.0.0 --port 3000",
+    "dev": "pnpm contract:build && pnpm logger:build && next dev --hostname 0.0.0.0 --port 3000",
+    "dev:run": "next dev --hostname 0.0.0.0 --port 3000",
     "logger:build": "pnpm --dir ../.. --filter @focusbuddy/logger build",
     "lint": "pnpm lint:styles && pnpm --dir ../.. exec oxlint apps/web/src apps/web/test && pnpm --dir ../.. lint:boundaries",
     "lint:styles": "pnpm --dir ../.. exec stylelint \"apps/web/src/**/*.css\"",

--- a/compose.local.yaml
+++ b/compose.local.yaml
@@ -41,72 +41,10 @@ services:
       timeout: 5s
       retries: 5
 
-  api:
-    build:
-      context: .
-      dockerfile: docker/local/node-dev.Dockerfile
-    working_dir: /workspace
-    command: ['pnpm', '--filter', '@focusbuddy/api', 'dev']
-    environment:
-      PORT: 3001
-      DATABASE_URL: postgres://${POSTGRES_USER:-focusbuddy}:${POSTGRES_PASSWORD:-focusbuddy}@postgres:5432/${POSTGRES_DB:-focusbuddy}
-      FOCUSBUDDY_AUTH_MODE: ${FOCUSBUDDY_AUTH_MODE:-stub}
-      FOCUSBUDDY_AUTH_BASE_URL: http://auth:9099
-    volumes:
-      - ${FOCUSBUDDY_WORKSPACE_MOUNT:-.}:/workspace
-    ports:
-      - '${API_PORT:-3001}:3001'
-    depends_on:
-      postgres:
-        condition: service_healthy
-      auth:
-        condition: service_healthy
-    healthcheck:
-      test:
-        [
-          'CMD',
-          'node',
-          '-e',
-          "fetch('http://127.0.0.1:3001/health').then((response)=>{if(!response.ok) process.exit(1)}).catch(()=>process.exit(1))",
-        ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-  web:
-    build:
-      context: .
-      dockerfile: docker/local/node-dev.Dockerfile
-    working_dir: /workspace
-    command: ['pnpm', '--filter', '@focusbuddy/web', 'dev:compose']
-    environment:
-      PORT: 3000
-      FOCUSBUDDY_API_BASE_URL: http://api:3001
-      NEXT_PUBLIC_FOCUSBUDDY_API_BASE_URL: http://localhost:${API_PORT:-3001}
-      NEXT_PUBLIC_FOCUSBUDDY_WEB_BASELINE_CAPTURE_ENABLED: ${NEXT_PUBLIC_FOCUSBUDDY_WEB_BASELINE_CAPTURE_ENABLED:-false}
-      NEXT_PUBLIC_FOCUSBUDDY_WEB_BASELINE_CAPTURE_CONTEXT: ${NEXT_PUBLIC_FOCUSBUDDY_WEB_BASELINE_CAPTURE_CONTEXT:-disabled}
-      FOCUSBUDDY_AUTH_MODE: ${FOCUSBUDDY_AUTH_MODE:-stub}
-      FOCUSBUDDY_AUTH_BASE_URL: http://auth:9099
-    volumes:
-      - ${FOCUSBUDDY_WORKSPACE_MOUNT:-.}:/workspace
-    ports:
-      - '${WEB_PORT:-3000}:3000'
-    depends_on:
-      api:
-        condition: service_healthy
-      auth:
-        condition: service_healthy
-    healthcheck:
-      test:
-        [
-          'CMD',
-          'node',
-          '-e',
-          "fetch('http://127.0.0.1:3000/health').then((response)=>{if(!response.ok) process.exit(1)}).catch(()=>process.exit(1))",
-        ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
 volumes:
   focusbuddy-postgres-data:
+
+networks:
+  default:
+    name: focusbuddy-net
+    external: true

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "build": "pnpm generate && turbo run build",
-    "dev": "turbo run dev --parallel",
+    "dev": "pnpm dev:prebuild && concurrently -k -n logger,api,web -c blue,green,magenta \"pnpm --filter @focusbuddy/logger dev\" \"pnpm --filter @focusbuddy/api dev:run\" \"pnpm --filter @focusbuddy/web dev:run\"",
+    "dev:prebuild": "pnpm --filter @focusbuddy/api-contract build && pnpm --filter @focusbuddy/logger build && pnpm --filter @focusbuddy/api prisma:generate",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "generate": "turbo run generate",
@@ -33,6 +34,7 @@
     "@commitlint/config-conventional": "^20.5.0",
     "@commitlint/types": "^20.5.0",
     "@jest/globals": "^30.3.0",
+    "concurrently": "^9.2.1",
     "husky": "^9.1.7",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@jest/globals':
         specifier: ^30.3.0
         version: 30.3.0
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -2889,6 +2892,11 @@ packages:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
 
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
@@ -5117,6 +5125,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   shimmer@1.2.1:
     resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
@@ -8732,6 +8744,15 @@ snapshots:
       readable-stream: 3.6.2
       typedarray: 0.0.6
 
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+
   confbox@0.2.4: {}
 
   configstore@5.0.1:
@@ -11305,6 +11326,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.3: {}
 
   shimmer@1.2.1: {}
 

--- a/scripts/local-dev/restart-running-app-services.sh
+++ b/scripts/local-dev/restart-running-app-services.sh
@@ -28,7 +28,7 @@ restart_services=("$@")
 if [[ $# -eq 0 ]]; then
   running_services="$(docker compose -f "$compose_file" ps --status running --services 2>/dev/null || true)"
 
-  for service_name in auth api web; do
+  for service_name in auth; do
     if grep -qx "$service_name" <<<"$running_services"; then
       restart_services+=("$service_name")
     fi

--- a/scripts/local-dev/up.sh
+++ b/scripts/local-dev/up.sh
@@ -7,7 +7,7 @@ require_docker
 restart_services=()
 running_services="$(docker compose -f compose.local.yaml ps --status running --services 2>/dev/null || true)"
 
-for service_name in auth api web; do
+for service_name in auth; do
   if grep -qx "$service_name" <<<"$running_services"; then
     restart_services+=("$service_name")
   fi

--- a/scripts/local-dev/verify.sh
+++ b/scripts/local-dev/verify.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Smoke verify the local-dev setup from inside the devcontainer.
+#
+# Run this after `Reopen in Container` + `just dev` (postgres / auth up).
+# It catches regressions where devcontainer.json / compose.local.yaml /
+# .env drift apart and the container can no longer reach the dependency
+# services by hostname (the silent failure mode that motivated this script).
+#
+# Tools used: getent, bash /dev/tcp, curl. nc / jq / ss are intentionally
+# avoided so the script runs on the bare node:24-bookworm base image.
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env"
+NETWORK_NAME="focusbuddy-net"
+POSTGRES_HOST="postgres"
+POSTGRES_PORT="5432"
+AUTH_HOST="auth"
+AUTH_PORT="9099"
+TCP_TIMEOUT_SECONDS="2"
+
+failures=()
+
+pass() {
+  printf '[verify] OK   %s\n' "$1"
+}
+
+fail() {
+  printf '[verify] FAIL %s\n' "$1" >&2
+  failures+=("$1")
+}
+
+check_dns() {
+  local host="$1"
+  if getent hosts "$host" >/dev/null 2>&1; then
+    pass "DNS: $host resolves"
+  else
+    fail "DNS: $host does not resolve (devcontainer not on $NETWORK_NAME?)"
+  fi
+}
+
+check_tcp() {
+  local host="$1"
+  local port="$2"
+  if timeout "$TCP_TIMEOUT_SECONDS" bash -c "exec 3<>/dev/tcp/${host}/${port}" >/dev/null 2>&1; then
+    pass "TCP: ${host}:${port} reachable"
+  else
+    fail "TCP: ${host}:${port} not reachable (compose service down?)"
+  fi
+}
+
+check_http_ok() {
+  local label="$1"
+  local url="$2"
+  # Bypass the egress proxy (tinyproxy) for intra-container traffic; the
+  # allowlist only covers external hosts, so auth/postgres on focusbuddy-net
+  # would otherwise return 403 even when the service is healthy.
+  if curl --noproxy '*' --silent --show-error --fail --max-time 5 --output /dev/null "$url"; then
+    pass "HTTP: ${label} ${url} returned 2xx"
+  else
+    fail "HTTP: ${label} ${url} did not return 2xx"
+  fi
+}
+
+check_env_key() {
+  local key="$1"
+  if [ ! -f "$ENV_FILE" ]; then
+    fail ".env: missing $ENV_FILE"
+    return
+  fi
+  if grep -Eq "^${key}=" "$ENV_FILE"; then
+    pass ".env: ${key} is set"
+  else
+    fail ".env: ${key} is not set"
+  fi
+}
+
+# 1. Sanity: we are inside a container.
+if [ -f /.dockerenv ]; then
+  pass "running inside a container"
+else
+  fail "not running inside a container (run from devcontainer)"
+fi
+
+# 2. DNS join — proves runArgs --network ${NETWORK_NAME} took effect.
+check_dns "$POSTGRES_HOST"
+check_dns "$AUTH_HOST"
+
+# 3. TCP reachability — proves compose stack is up on the shared network.
+check_tcp "$POSTGRES_HOST" "$POSTGRES_PORT"
+check_tcp "$AUTH_HOST" "$AUTH_PORT"
+
+# 4. Auth health endpoint — proves auth-stub is actually serving HTTP.
+check_http_ok "auth /health" "http://${AUTH_HOST}:${AUTH_PORT}/health"
+
+# 5. .env wiring — proves ad-hoc dev DSN/URL are populated.
+check_env_key "DATABASE_URL"
+check_env_key "FOCUSBUDDY_AUTH_BASE_URL"
+
+if [ ${#failures[@]} -eq 0 ]; then
+  echo "[verify] All checks passed."
+  exit 0
+fi
+
+echo "[verify] ${#failures[@]} check(s) failed:" >&2
+for entry in "${failures[@]}"; do
+  echo "  - $entry" >&2
+done
+exit 1


### PR DESCRIPTION
Closes #189

## Summary

- `compose.local.yaml` から `web` / `api` を削除し、依存サービス(postgres/auth)のみを compose で管理
- ネットワークを `focusbuddy-net` external に統一し、devcontainer も `--network focusbuddy-net` で join
- devcontainer に `forwardPorts: [3000, 3001]` を追加
- `.devcontainer/initialize.sh` でホスト側の `focusbuddy-net` を冪等に作成
- ルート `pnpm dev` を `concurrently -k` 構成に変更し、prebuild は `dev:prebuild` に集約
- `apps/api` / `apps/web` に `dev:run` を追加(prebuild なしで `tsx watch` / `next dev` を起動)
- `scripts/local-dev/up.sh` / `restart-running-app-services.sh` の対象を `auth` のみに縮小
- `.env.example` に ad-hoc 起動向け `DATABASE_URL` / `FOCUSBUDDY_AUTH_BASE_URL` の例を追記

## Test plan

- [ ] devcontainer を Reopen in Container で再構築し、`focusbuddy-net` network が存在することを確認
- [ ] `docker compose -f compose.local.yaml up -d` で postgres/auth のみが起動する
- [ ] devcontainer 内から `getent hosts postgres` / `getent hosts auth` で名前解決できる
- [ ] `pnpm dev` で logger watch / api / web が起動し、3 プロセスとも Ready になる
- [ ] ホストブラウザから http://localhost:3000 / http://localhost:3001/health にアクセスできる
- [ ] いずれか 1 プロセスを Ctrl+C で落とすと concurrently の `-k` で全プロセスが停止する

🤖 Generated with [Claude Code](https://claude.com/claude-code)